### PR TITLE
feat: add tenant creation feedback and halt push on duplicate tenants

### DIFF
--- a/packages/cli/src/commands/schema/push.ts
+++ b/packages/cli/src/commands/schema/push.ts
@@ -63,13 +63,19 @@ export default class SchemaPush extends Command {
     createTenantIfNotExists?: boolean
   ) {
     try {
-      await writeSchemaToPermify({
+      const { tenantStatus } = await writeSchemaToPermify({
         endpoint: "",
         tenantId,
         schema,
         createTenantIfNotExists,
         client
       });
+
+      if (tenantStatus.created) {
+        this.log(`✔ Tenant created successfully`);
+      } else if (tenantStatus.alreadyExisted && createTenantIfNotExists) {
+        this.log(`ℹ Tenant already exists`);
+      }
     } catch (err: any) {
       this.error(`Schema push failed:\n${err.message}`);
     }


### PR DESCRIPTION
Improved tenant handling in the core and CLI packages:

- **Core:** Enhanced _writeSchemaToPermify_ to return detailed tenant status and improved "already exists" detection (handling ERROR_CODE_UNIQUE_CONSTRAINT).
- **Logic Change:** The schema push now halts immediately if a tenant already exists while using the creation flag, preventing unintended overwrites.
- **CLI:** Added success/info logging for tenant operations and surfaced specific error codes for better debugging.
- **Refactor:** Improved test type safety by removing any casts and implementing a _withEnv_ helper for environment variable management.
