### PR TITLE
feat: Add CLI command to seed relationships and refactor core write o…

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -146,6 +146,82 @@ The Permify server validates your schema when you push it. If there are any erro
 Error: Entity "usr" referenced in relation "document.owner" does not exist
 ```
 
+### `relationships seed`
+
+Seeds relationship data from a JSON file to the configured Permify server.
+
+**Usage:**
+
+```bash
+permify-toolkit relationships seed --tenant <tenant-id> --file-path <path-to-file> [flags]
+```
+
+**Flags:**
+
+| Flag              | Alias | Description                                             | Required | Default |
+| :---------------- | :---- | :------------------------------------------------------ | :------- | :------ |
+| `--tenant`        |       | The Tenant ID to seed relationships to.                 | Yes      | -       |
+| `--file-path`     | `-f`  | Path to the JSON file containing relationship tuples.   | Yes      | -       |
+| `--create-tenant` | `-c`  | Creates the tenant if it does not exist before seeding. | No       | `false` |
+
+**Example `relationships.json` file:**
+
+The JSON file must contain a `tuples` array, where each tuple object has `entity`, `relation`, and `subject` fields.
+
+```json
+{
+  "tuples": [
+    {
+      "entity": {
+        "type": "organization",
+        "id": "org_1"
+      },
+      "relation": "member",
+      "subject": {
+        "type": "user",
+        "id": "alice"
+      }
+    },
+    {
+      "entity": {
+        "type": "document",
+        "id": "doc_1"
+      },
+      "relation": "owner",
+      "subject": {
+        "type": "user",
+        "id": "bob"
+      }
+    },
+    {
+      "entity": {
+        "type": "document",
+        "id": "doc_1"
+      },
+      "relation": "viewer",
+      "subject": {
+        "type": "user",
+        "id": "charlie"
+      }
+    }
+  ]
+}
+```
+
+**Examples:**
+
+Seed relationships to an existing tenant:
+
+```bash
+permify-toolkit relationships seed --tenant my-tenant-id --file-path ./data/relationships.json
+```
+
+Seed relationships to a new tenant:
+
+```bash
+permify-toolkit relationships seed --tenant new-tenant-id --file-path ./relationships.json --create-tenant
+```
+
 ## Development
 
 To develop and test changes locally:

--- a/packages/cli/relationships.json
+++ b/packages/cli/relationships.json
@@ -1,0 +1,59 @@
+{
+  "tuples": [
+    {
+      "entity": {
+        "type": "dashboard",
+        "id": "dashboard_1"
+      },
+      "relation": "viewers",
+      "subject": {
+        "type": "role",
+        "id": "TL"
+      }
+    },
+    {
+      "entity": {
+        "type": "dashboard",
+        "id": "dashboard_1"
+      },
+      "relation": "viewers",
+      "subject": {
+        "type": "role",
+        "id": "QA"
+      }
+    },
+    {
+      "entity": {
+        "type": "dashboard",
+        "id": "dashboard_1"
+      },
+      "relation": "viewers",
+      "subject": {
+        "type": "role",
+        "id": "ADMIN"
+      }
+    },
+    {
+      "entity": {
+        "type": "dashboard",
+        "id": "dashboard_1"
+      },
+      "relation": "viewers",
+      "subject": {
+        "type": "role",
+        "id": "SUPER_ADMIN"
+      }
+    },
+    {
+      "entity": {
+        "type": "dashboard",
+        "id": "dashboard_1"
+      },
+      "relation": "viewers",
+      "subject": {
+        "type": "role",
+        "id": "AGENT"
+      }
+    }
+  ]
+}

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -1,0 +1,37 @@
+import { Command, Flags } from "@oclif/core";
+import { createPermifyClient, type Config } from "@permify-toolkit/core";
+
+import { loadConfig } from "./helpers.js";
+
+export abstract class BaseCommand extends Command {
+  static baseFlags = {
+    tenant: Flags.string({
+      description: "Permify tenant ID",
+      env: "PERMIFY_TENANT",
+      required: true
+    }),
+    "create-tenant": Flags.boolean({
+      char: "c",
+      description: "Create tenant if it does not exist",
+      default: false
+    })
+  };
+
+  protected async clientFromConfig(): Promise<{
+    client: any;
+    config: Config;
+  }> {
+    const config = await loadConfig();
+
+    if (!config.schema) {
+      this.error("Schema not defined in config");
+    }
+
+    if (!config.client?.endpoint) {
+      this.error("Client endpoint not defined in config");
+    }
+
+    const client = createPermifyClient(config.client);
+    return { client, config };
+  }
+}

--- a/packages/cli/src/commands/relationships/seed.ts
+++ b/packages/cli/src/commands/relationships/seed.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Flags } from "@oclif/core";
+import { writeRelationships, type Relationship } from "@permify-toolkit/core";
+
+import { BaseCommand } from "../../base.js";
+
+export default class RelationshipSeed extends BaseCommand {
+  static description = "Seed relationships from a JSON file";
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    "file-path": Flags.string({
+      char: "f",
+      description: "Path to the relationship JSON file",
+      required: true
+    })
+  };
+
+  async run() {
+    const { flags } = await this.parse(RelationshipSeed);
+
+    // 1. Validate File
+    const relationships = this.validateRelationshipFile(flags["file-path"]);
+
+    if (relationships.length === 0) {
+      this.log("No relationships found in file.");
+      return;
+    }
+
+    // 2. Initialize Client
+    const { client } = await this.clientFromConfig();
+
+    // 3. Write Relationships
+    try {
+      this.log(`Seeding ${relationships.length} relationships...`);
+      const result = await writeRelationships({
+        client,
+        tenantId: flags.tenant,
+        relationships: { tuples: relationships },
+        createTenantIfNotExists: flags["create-tenant"],
+        endpoint: ""
+      });
+
+      if (result.tenantStatus.created) {
+        this.log(`✔ Tenant created successfully`);
+      } else if (result.tenantStatus.alreadyExisted && flags["create-tenant"]) {
+        this.log(`ℹ Tenant already exists`);
+      }
+
+      this.log(`✔ Successfully seeded ${result.count} relationships.`);
+    } catch (err: any) {
+      this.error(`Failed during seed: ${err.message}`);
+    }
+  }
+
+  private validateRelationshipFile(filePath: string): Relationship[] {
+    const fullPath = path.resolve(filePath);
+    if (!fs.existsSync(fullPath)) {
+      this.error(`File not found: ${fullPath}`);
+    }
+
+    let fileContent: string;
+    try {
+      fileContent = fs.readFileSync(fullPath, "utf-8");
+    } catch (err: any) {
+      this.error(`Failed to read file: ${err.message}`);
+    }
+
+    if (!fileContent.trim()) {
+      this.error("File is empty");
+    }
+
+    let relationships: { tuples: Relationship[] };
+    try {
+      relationships = JSON.parse(fileContent);
+    } catch (err: any) {
+      this.error(`Invalid JSON: ${err.message}`);
+    }
+
+    if (!Array.isArray(relationships.tuples)) {
+      this.error("File content must be an array of relationships");
+    }
+
+    return relationships.tuples;
+  }
+}

--- a/packages/cli/src/commands/schema/push.ts
+++ b/packages/cli/src/commands/schema/push.ts
@@ -1,42 +1,22 @@
-import { Command, Flags } from "@oclif/core";
-import {
-  writeSchemaToPermify,
-  createPermifyClient
-} from "@permify-toolkit/core";
+import { writeSchemaToPermify } from "@permify-toolkit/core";
 
-import { loadConfig, loadSchemaFromConfig } from "../../helpers.js";
+import { BaseCommand } from "../../base.js";
+import { loadSchemaFromConfig } from "../../helpers.js";
 
-export default class SchemaPush extends Command {
+export default class SchemaPush extends BaseCommand {
   static description = "Push Permify schema to the server";
 
   static args = {};
 
   static flags = {
-    tenant: Flags.string({
-      description: "Permify tenant ID",
-      env: "PERMIFY_TENANT",
-      required: true
-    }),
-    "create-tenant": Flags.boolean({
-      char: "c",
-      description: "Create tenant if it does not exist",
-      default: false
-    })
+    ...BaseCommand.baseFlags
   };
 
   async run() {
     const { flags } = await this.parse(SchemaPush);
 
-    // 1️⃣ Load config
-    const config = await loadConfig();
-
-    if (!config.schema) {
-      this.error("Schema not defined in config");
-    }
-
-    if (!config.client?.endpoint) {
-      this.error("Client endpoint not defined in config");
-    }
+    // 1️⃣ Load config and client
+    const { client, config } = await this.clientFromConfig();
 
     // 2️⃣ Load schema (compile AST or read file)
     let dsl: string;
@@ -46,10 +26,7 @@ export default class SchemaPush extends Command {
       this.error(`Failed to load schema: ${err.message}`);
     }
 
-    // 3️⃣ Create client with full config
-    const client = createPermifyClient(config.client);
-
-    // 4️⃣ Push schema via core
+    // 3️⃣ Push schema via core
     await this.pushSchema(dsl, client, flags.tenant, flags["create-tenant"]);
 
     this.log(`✔ Schema pushed successfully`);

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -37,6 +37,25 @@ export async function loadConfig(): Promise<Config> {
 }
 
 /**
+ * Validates the schema file path and returns the full path.
+ *
+ * @param schemaPath - The path to the schema file
+ * @returns The full path to the schema file
+ */
+export function validateSchemaFile(schemaPath: string): string {
+  const fullPath = path.resolve(schemaPath);
+
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`Schema file not found: ${fullPath}`);
+  }
+
+  if (!fullPath.endsWith(".perm")) {
+    throw new Error(`Schema file must end with .perm extension: ${fullPath}`);
+  }
+  return fullPath;
+}
+
+/**
  * Loads schema from config, handling both AST-based and file-based schemas.
  *
  * @param schema - Either a SchemaHandle or a file path string
@@ -48,15 +67,7 @@ export function loadSchemaFromConfig(schema: SchemaHandle | string): string {
   }
 
   if (typeof schema === "string") {
-    const fullPath = path.resolve(schema);
-
-    if (!fs.existsSync(fullPath)) {
-      throw new Error(`Schema file not found: ${fullPath}`);
-    }
-
-    if (!fullPath.endsWith(".perm")) {
-      throw new Error(`Schema file must end with .perm extension: ${fullPath}`);
-    }
+    const fullPath = validateSchemaFile(schema);
 
     try {
       return fs.readFileSync(fullPath, "utf-8");

--- a/packages/core/src/common/base-writer.ts
+++ b/packages/core/src/common/base-writer.ts
@@ -1,0 +1,76 @@
+import { ensureTenant } from "../helpers.js";
+import { createPermifyClient } from "../client/index.js";
+
+export interface BaseWriteParams {
+  endpoint: string;
+  tenantId: string;
+  createTenantIfNotExists?: boolean;
+  client?: any;
+}
+
+export interface BaseWriterResult {
+  tenantStatus: {
+    created: boolean;
+    alreadyExisted: boolean;
+  };
+}
+
+export abstract class BasePermifyWriter<
+  TParams extends BaseWriteParams,
+  TResult
+> {
+  async execute(params: TParams): Promise<TResult & BaseWriterResult> {
+    this.validate(params);
+
+    const client =
+      params.client || createPermifyClient({ endpoint: params.endpoint });
+
+    const { created, alreadyExisted } = await ensureTenant(
+      client,
+      params.tenantId,
+      !!params.createTenantIfNotExists
+    );
+
+    try {
+      const result = await this.performWrite(client, params);
+      return { ...result, tenantStatus: { created, alreadyExisted } };
+    } catch (error: any) {
+      if (created) {
+        await this.rollbackTenant(client, params.tenantId, error);
+      }
+      throw error;
+    }
+  }
+
+  protected validate(params: TParams): void {
+    if (!params.client && !params.endpoint) {
+      throw new Error("Either endpoint or client must be provided");
+    }
+    if (!params.tenantId) throw new Error("Tenant ID is required");
+  }
+
+  protected abstract performWrite(
+    client: any,
+    params: TParams
+  ): Promise<TResult>;
+
+  private async rollbackTenant(
+    client: any,
+    tenantId: string,
+    originalError: Error
+  ): Promise<never> {
+    try {
+      await client.tenancy.delete({ id: tenantId });
+      throw new Error(
+        `Operation failed: ${originalError.message}. Tenant ${tenantId} was rolled back (deleted).`
+      );
+    } catch (rollbackErr: any) {
+      if (rollbackErr.message.includes("Operation failed:")) {
+        throw rollbackErr;
+      }
+      throw new Error(
+        `Operation failed: ${originalError.message}. Rollback failed: ${rollbackErr.message}. Tenant ${tenantId} may be in an inconsistent state.`
+      );
+    }
+  }
+}

--- a/packages/core/src/data/write-relationships.ts
+++ b/packages/core/src/data/write-relationships.ts
@@ -1,0 +1,59 @@
+import {
+  BasePermifyWriter,
+  type BaseWriteParams,
+  type BaseWriterResult
+} from "../common/base-writer.js";
+
+export interface Relationship {
+  entity: {
+    type: string;
+    id: string;
+  };
+  relation: string;
+  subject: {
+    type: string;
+    id: string;
+    relation?: string;
+  };
+}
+
+interface WriteRelationshipsParams extends BaseWriteParams {
+  relationships: {
+    tuples: Relationship[];
+  };
+}
+
+interface WriteRelationshipsResult extends BaseWriterResult {
+  success: boolean;
+  count: number;
+}
+
+class RelationshipWriter extends BasePermifyWriter<
+  WriteRelationshipsParams,
+  { success: boolean; count: number }
+> {
+  protected async performWrite(
+    client: any,
+    params: WriteRelationshipsParams
+  ): Promise<{ success: boolean; count: number }> {
+    const tuples = params.relationships.tuples;
+
+    await client.data.write({
+      tenantId: params.tenantId,
+      metadata: {
+        schemaVersion: ""
+      },
+      tuples
+    });
+
+    return { success: true, count: tuples.length };
+  }
+}
+
+// Writes relationships to the Permify server.
+export async function writeRelationships(
+  params: WriteRelationshipsParams
+): Promise<WriteRelationshipsResult> {
+  const writer = new RelationshipWriter();
+  return writer.execute(params);
+}

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,0 +1,70 @@
+export interface TenantOperationResult {
+  created: boolean;
+  alreadyExisted: boolean;
+}
+
+/**
+ * Helper to check if a tenant exists using pagination.
+ */
+export async function checkTenantExists(
+  client: any,
+  tenantId: string
+): Promise<boolean> {
+  let continuousToken = "";
+
+  do {
+    const response = await client.tenancy.list({
+      pageSize: 20,
+      continuousToken
+    });
+
+    if (response.tenants.some((t: any) => t.id === tenantId)) {
+      return true;
+    }
+
+    continuousToken = response.continuousToken;
+  } while (continuousToken);
+
+  return false;
+}
+
+/**
+ * Ensures the tenant exists, creating it if requested and necessary.
+ * Returns metadata indicating if a new tenant was created.
+ */
+export async function ensureTenant(
+  client: any,
+  tenantId: string,
+  shouldCreate: boolean
+): Promise<TenantOperationResult> {
+  if (shouldCreate) {
+    try {
+      await client.tenancy.create({ id: tenantId, name: tenantId });
+      return { created: true, alreadyExisted: false };
+    } catch (err: any) {
+      // Ignore "already exists" errors:
+      // - code 6 is ALREADY_EXISTS in standard gRPC
+      // - ERROR_CODE_UNIQUE_CONSTRAINT is Permify's specific error message
+      const isAlreadyExists =
+        err.code === 6 ||
+        err.message.includes("already exists") ||
+        err.message.includes("ERROR_CODE_UNIQUE_CONSTRAINT");
+
+      if (!isAlreadyExists) {
+        throw err;
+      }
+      throw new Error(
+        `Tenant with name ${tenantId} already exists (ERROR_CODE_UNIQUE_CONSTRAINT)`
+      );
+    }
+  }
+
+  const exists = await checkTenantExists(client, tenantId);
+  if (!exists) {
+    throw new Error(
+      `Tenant "${tenantId}" not found. Use --create-tenant to create it automatically.`
+    );
+  }
+
+  return { created: false, alreadyExisted: true };
+}

--- a/packages/core/src/public-api.ts
+++ b/packages/core/src/public-api.ts
@@ -29,3 +29,8 @@ export {
   clientOptionsFromEnv,
   type PermifyClientOptions
 } from "./client/index.js";
+
+export {
+  writeRelationships,
+  type Relationship
+} from "./data/write-relationships.js";

--- a/packages/core/src/schema/write-schema.ts
+++ b/packages/core/src/schema/write-schema.ts
@@ -1,176 +1,47 @@
-import { createPermifyClient } from "../client/index.js";
+import {
+  BasePermifyWriter,
+  type BaseWriteParams,
+  type BaseWriterResult
+} from "../common/base-writer.js";
 
-interface WriteSchemaParams {
-  endpoint: string;
-  tenantId: string;
+interface WriteSchemaParams extends BaseWriteParams {
   schema: string;
-  createTenantIfNotExists?: boolean;
-  client?: any;
 }
 
-interface TenantOperationResult {
-  created: boolean;
-  alreadyExisted: boolean;
-}
-
-interface WriteSchemaResult {
+interface WriteSchemaResult extends BaseWriterResult {
   schema: string;
-  tenantStatus: {
-    created: boolean;
-    alreadyExisted: boolean;
-  };
 }
 
-/**
- * Validates the required parameters for writing a schema.
- */
-function validateParams(params: WriteSchemaParams): void {
-  const { endpoint, tenantId, schema, client } = params;
-
-  if (!client && !endpoint) {
-    throw new Error("Either endpoint or client must be provided");
+class SchemaWriter extends BasePermifyWriter<
+  WriteSchemaParams,
+  { schema: string }
+> {
+  protected validate(params: WriteSchemaParams): void {
+    super.validate(params);
+    if (!params.schema) throw new Error("Schema is required");
+    if (typeof params.schema !== "string")
+      throw new Error("Schema must be a string");
   }
 
-  if (!tenantId) throw new Error("Tenant ID is required");
-  if (!schema) throw new Error("Schema is required");
-  if (typeof schema !== "string") throw new Error("Schema must be a string");
-}
-
-/**
- * Helper to check if a tenant exists using pagination.
- */
-async function checkTenantExists(
-  client: any,
-  tenantId: string
-): Promise<boolean> {
-  let continuousToken = "";
-
-  do {
-    const response = await client.tenancy.list({
-      pageSize: 20,
-      continuousToken
+  protected async performWrite(
+    client: any,
+    params: WriteSchemaParams
+  ): Promise<{ schema: string }> {
+    await client.schema.write({
+      tenantId: params.tenantId,
+      schema: params.schema
     });
-
-    if (response.tenants.some((t: any) => t.id === tenantId)) {
-      return true;
-    }
-
-    continuousToken = response.continuousToken;
-  } while (continuousToken);
-
-  return false;
-}
-
-/**
- * Ensures the tenant exists, creating it if requested and necessary.
- * Returns metadata indicating if a new tenant was created.
- */
-async function ensureTenant(
-  client: any,
-  tenantId: string,
-  shouldCreate: boolean
-): Promise<TenantOperationResult> {
-  if (shouldCreate) {
-    try {
-      await client.tenancy.create({ id: tenantId, name: tenantId });
-      return { created: true, alreadyExisted: false };
-    } catch (err: any) {
-      // Ignore "already exists" errors:
-      // - code 6 is ALREADY_EXISTS in standard gRPC
-      // - ERROR_CODE_UNIQUE_CONSTRAINT is Permify's specific error message
-      const isAlreadyExists =
-        err.code === 6 ||
-        err.message.includes("already exists") ||
-        err.message.includes("ERROR_CODE_UNIQUE_CONSTRAINT");
-
-      if (!isAlreadyExists) {
-        throw err;
-      }
-      throw new Error(
-        `Tenant with name ${tenantId} already exists (ERROR_CODE_UNIQUE_CONSTRAINT)`
-      );
-    }
+    return { schema: params.schema };
   }
-
-  const exists = await checkTenantExists(client, tenantId);
-  if (!exists) {
-    throw new Error(
-      `Tenant ${tenantId} not found. Use --create-tenant to create it automatically.`
-    );
-  }
-
-  return { created: false, alreadyExisted: true };
 }
 
 /**
  * Writes the schema DSL to the Permify server.
  * Permify validates the schema and returns an error if invalid.
  */
-async function deploySchema(client: any, tenantId: string, schema: string) {
-  await client.schema.write({
-    tenantId,
-    schema
-  });
-  return { schema };
-}
-
-/**
- * Attempts to rollback (delete) a newly created tenant in case of failure.
- */
-async function rollbackTenant(
-  client: any,
-  tenantId: string,
-  originalError: Error
-): Promise<never> {
-  try {
-    await client.tenancy.delete({ id: tenantId });
-    throw new Error(
-      `Schema write failed: ${originalError.message}. Tenant ${tenantId} was rolled back (deleted).`
-    );
-  } catch (rollbackErr: any) {
-    // If the rollback itself fails, we must report both errors to avoid swallowing the critical state issue
-    // Ensure we don't throw the original error if we are throwing this new one
-    if (rollbackErr.message.includes("Schema write failed:")) {
-      throw rollbackErr;
-    }
-
-    throw new Error(
-      `Schema write failed: ${originalError.message}. Rollback failed: ${rollbackErr.message}. Tenant ${tenantId} may be in an inconsistent state.`
-    );
-  }
-}
-
-/**
- * Writes a compiled schema to a Permify server with transactional safety.
- *
- * This function orchestrates the workflow:
- * 1. Validation
- * 2. Client Initialization
- * 3. Tenant Verification/Creation
- * 4. Schema Deployment (Permify validates the schema)
- * 5. Automatic Rollback on Failure
- */
 export async function writeSchemaToPermify(
   params: WriteSchemaParams
 ): Promise<WriteSchemaResult> {
-  validateParams(params);
-
-  const client =
-    params.client || createPermifyClient({ endpoint: params.endpoint });
-
-  const { created, alreadyExisted } = await ensureTenant(
-    client,
-    params.tenantId,
-    !!params.createTenantIfNotExists
-  );
-
-  try {
-    const result = await deploySchema(client, params.tenantId, params.schema);
-    return { ...result, tenantStatus: { created, alreadyExisted } };
-  } catch (error: any) {
-    if (created) {
-      await rollbackTenant(client, params.tenantId, error);
-    }
-    throw error;
-  }
+  const writer = new SchemaWriter();
+  return writer.execute(params);
 }


### PR DESCRIPTION
# feat(cli): Initial relationships seed command

## Summary

This PR introduces the `relationships seed` command to the Permify Toolkit CLI, allowing users to seed relationship data from a JSON file. It also includes refactoring of the core write logic to a shared base class for better maintainability.

## Key Changes

- **CLI**: Added `relationships seed` command.
  - Usage: `permify-toolkit relationships seed --tenant <id> --file-path <path>`
  - Supports `--create-tenant` flag.
  - Validates input file structure.
- **Core**: Introduced `BasePermifyWriter` abstract class.
  - Refactored `writeSchemaToPermify` and `writeRelationships` to use this shared base for consistent validation, tenant management, and error handling.
- **Documentation**: Updated `README.md` with usage instructions and example data format for the new command.

## How to Test

1.  Build the packages: `pnpm build`
2.  Run the seed command with a valid `relationships.json` file:
    ```bash
    ./bin/permify-toolkit relationships seed --tenant <your-tenant> --file-path ./relationships.json --create-tenant
    ```
