### PR TITLE
chore: add Renovate configuration for dependency management and autom…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "timezone": "Asia/Kolkata",
+  "schedule": ["before 9am on monday"],
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 10,
+  "dependencyDashboard": true,
+  "separateMajorMinor": true,
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on monday"]
+  },
+  "major": {
+    "addLabels": ["major"]
+  },
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "devDependencies (non-major)",
+      "addLabels": ["dev"]
+    },
+    {
+      "matchPackageNames": ["/^@types\\//"],
+      "groupName": "type definitions",
+      "addLabels": ["types"]
+    },
+    {
+      "matchFileNames": ["packages/*/package.json"],
+      "matchDepTypes": ["dependencies"],
+      "groupName": null,
+      "addLabels": ["prod"]
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "replace",
+      "addLabels": ["peer"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "groupName": "github-actions",
+      "addLabels": ["ci"]
+    }
+  ]
+}


### PR DESCRIPTION
## Add renovate dependencies update bot

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## Affected Package(s)

- [ ] `@permify-toolkit/core`
- [ ] `@permify-toolkit/nestjs`
- [ ] `@permify-toolkit/cli`
- [ ] Simulator / docs

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the existing style (ran `pnpm lint` and `pnpm format:check`)
- [x] Tests are passing (`pnpm test`)
- [ ] I have added/updated tests for new behavior
- [ ] I have run `pnpm changeset` if this change affects a published package
- [ ] Public API changes are reflected in `src/public-api.ts`

## Related Issues

none
