### PR TITLE
Feat/core standalone dx

### DIFF
--- a/.changeset/core-standalone-dx.md
+++ b/.changeset/core-standalone-dx.md
@@ -1,0 +1,12 @@
+---
+"@permify-toolkit/core": minor
+---
+
+Improve standalone DX for relationship and config APIs:
+
+- `BaseWriteParams.endpoint` is now optional when `client` is provided. Affects `writeSchemaToPermify`, `readSchemaFromPermify`, `writeRelationships`, `deleteRelationships`.
+- `writeRelationships` now accepts `tuples` directly at the top level. The nested `relationships: { tuples }` form still works but is deprecated.
+- New exported helper `tupleFilter()` (and `TupleFilterInput` type) for building Permify-shaped relationship filters from a partial input. `deleteRelationships` now normalizes its `filter` the same way `readRelationships` already did, so partial filters no longer hit the gRPC defaults gap.
+- `loadConfig` accepts a `cwd` option to resolve the default config file from a directory other than `process.cwd()`.
+
+No breaking changes.

--- a/docs-site/docs/packages/core.md
+++ b/docs-site/docs/packages/core.md
@@ -80,7 +80,7 @@ See [Configuration](/docs/configuration) for all client options.
 ```typescript
 import { checkPermission } from "@permify-toolkit/core";
 
-const { allowed } = await checkPermission(client, {
+const allowed = await checkPermission(client, {
   tenantId: "my-tenant",
   entity: { type: "document", id: "doc-1" },
   permission: "view",
@@ -93,7 +93,8 @@ const { allowed } = await checkPermission(client, {
 ```typescript
 import { writeRelationships } from "@permify-toolkit/core";
 
-await writeRelationships(client, {
+await writeRelationships({
+  client,
   tenantId: "my-tenant",
   tuples: [
     {
@@ -104,6 +105,8 @@ await writeRelationships(client, {
   ]
 });
 ```
+
+You can pass `client` (recommended) or just an `endpoint` string — the helper will create a client for you. Either is sufficient; you don't need both.
 
 ### Reading Relationships
 
@@ -175,19 +178,46 @@ await readRelationships({
 
 ### Deleting Relationships
 
+Deletes happen by filter, not by tuple. Provide any combination of `entity`, `relation`, and `subject` — anything you omit is treated as "match anything".
+
 ```typescript
 import { deleteRelationships } from "@permify-toolkit/core";
 
-await deleteRelationships(client, {
+// Remove every relationship on a specific document
+await deleteRelationships({
+  client,
   tenantId: "my-tenant",
-  tuples: [
-    {
-      entity: { type: "document", id: "doc-1" },
-      relation: "owner",
-      subject: { type: "user", id: "user-123" }
-    }
-  ]
+  filter: { entity: { type: "document", ids: ["doc-1"] } }
 });
+
+// Remove just the owner edge between alice and doc-1
+await deleteRelationships({
+  client,
+  tenantId: "my-tenant",
+  filter: {
+    entity: { type: "document", ids: ["doc-1"] },
+    relation: "owner",
+    subject: { type: "user", ids: ["alice"] }
+  }
+});
+```
+
+### Building Filters with `tupleFilter`
+
+Both `readRelationships` and `deleteRelationships` accept a partial filter and fill in defaults internally. If you need the fully-normalized gRPC shape (e.g. you're calling `client.data.*` directly, building filters in a helper, or asserting in tests), use `tupleFilter`:
+
+```typescript
+import { tupleFilter } from "@permify-toolkit/core";
+
+const filter = tupleFilter({
+  entity: { type: "document" },
+  relation: "viewer"
+});
+// {
+//   entity: { type: "document", ids: [] },
+//   relation: "viewer",
+//   subject: { type: "", ids: [], relation: "" }
+// }
 ```
 
 ## Reading Schemas
@@ -319,6 +349,20 @@ export default defineConfig({
 });
 ```
 
+### Loading a Config File
+
+`loadConfig` resolves and validates a `permify.config.ts`. By default it looks in `process.cwd()`; pass `cwd` to resolve from another directory, or pass an explicit path as the first argument.
+
+```typescript
+import { loadConfig } from "@permify-toolkit/core";
+
+const config = await loadConfig(); // ./permify.config.ts
+const fromMonorepoRoot = await loadConfig(undefined, { cwd: "/repo/root" });
+const customPath = await loadConfig("./configs/permify.ts");
+```
+
+If you already have an in-memory config object (e.g. from a test fixture), skip `loadConfig` entirely and use `defineConfig` + `validateConfig` directly — no filesystem access required.
+
 ## API Reference
 
 ### Exports
@@ -333,12 +377,15 @@ export default defineConfig({
 | `defineConfig()`          | Create a typed config object                                                                            |
 | `validateConfig()`        | Validate a config object                                                                                |
 | `schemaFile()`            | Reference a `.perm` schema file                                                                         |
+| `loadConfig()`            | Load and validate a `permify.config.ts` from disk                                                       |
+| `SeedingMode`             | Enum of seeding strategies (`APPEND`, `REPLACE`) used by config and CLI                                 |
 | `createPermifyClient()`   | Create a gRPC client                                                                                    |
 | `clientOptionsFromEnv()`  | Read client options from env vars                                                                       |
 | `checkPermission()`       | Check a permission                                                                                      |
 | `writeRelationships()`    | Write relationship tuples                                                                               |
 | `readRelationships()`     | Read relationship tuples with filtering and automatic pagination                                        |
-| `deleteRelationships()`   | Delete relationship tuples                                                                              |
+| `deleteRelationships()`   | Delete relationship tuples by filter                                                                    |
+| `tupleFilter()`           | Build a normalized relationship filter (fills gRPC defaults for omitted fields)                         |
 | `relationsOf()`           | Helper to extract relations from schema                                                                 |
 | `getSchemaWarnings()`     | Collect non-blocking warnings from a schema AST (unused relations, empty entities, missing permissions) |
 | `readSchemaFromPermify()` | Read the current schema from a Permify server for a given tenant                                        |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,7 @@ const client = createPermifyClient({
   insecure: true
 });
 
-const { allowed } = await checkPermission(client, {
+const allowed = await checkPermission(client, {
   tenantId: "t1",
   entity: { type: "document", id: "doc-1" },
   permission: "view",

--- a/packages/core/src/common/base-writer.ts
+++ b/packages/core/src/common/base-writer.ts
@@ -2,7 +2,8 @@ import { ensureTenant } from "../helpers.js";
 import { createPermifyClient } from "../client/index.js";
 
 export interface BaseWriteParams {
-  endpoint: string;
+  /** Permify endpoint. Optional when `client` is provided. */
+  endpoint?: string;
   tenantId: string;
   createTenantIfNotExists?: boolean;
   client?: any;
@@ -23,7 +24,8 @@ export abstract class BasePermifyWriter<
     this.validate(params);
 
     const client =
-      params.client || createPermifyClient({ endpoint: params.endpoint });
+      params.client ||
+      createPermifyClient({ endpoint: params.endpoint as string });
 
     const { created, alreadyExisted } = await ensureTenant(
       client,

--- a/packages/core/src/data/read-relationships.ts
+++ b/packages/core/src/data/read-relationships.ts
@@ -1,13 +1,10 @@
 import type { Relationship } from "./write-relationships.js";
+import { tupleFilter, type TupleFilterInput } from "./tuple-filter.js";
 
 export interface ReadRelationshipsParams {
   client: any;
   tenantId: string;
-  filter: {
-    entity: { type: string; ids?: string[] };
-    relation?: string;
-    subject?: { type: string; ids?: string[]; relation?: string };
-  };
+  filter: TupleFilterInput & { entity: { type: string; ids?: string[] } };
   pageSize?: number;
 }
 
@@ -16,20 +13,7 @@ export async function readRelationships(
 ): Promise<Relationship[]> {
   const { client, tenantId, filter, pageSize = 50 } = params;
 
-  const tupleFilter = {
-    entity: {
-      type: filter.entity.type,
-      ids: filter.entity.ids ?? []
-    },
-    relation: filter.relation ?? "",
-    subject: filter.subject
-      ? {
-          type: filter.subject.type,
-          ids: filter.subject.ids ?? [],
-          relation: filter.subject.relation ?? ""
-        }
-      : { type: "", ids: [], relation: "" }
-  };
+  const normalizedFilter = tupleFilter(filter);
 
   const allTuples: Relationship[] = [];
   let continuousToken = "";
@@ -38,7 +22,7 @@ export async function readRelationships(
     const response = await client.data.readRelationships({
       tenantId,
       metadata: { snapToken: "" },
-      filter: tupleFilter,
+      filter: normalizedFilter,
       pageSize,
       continuousToken
     });

--- a/packages/core/src/data/tuple-filter.ts
+++ b/packages/core/src/data/tuple-filter.ts
@@ -1,0 +1,48 @@
+/**
+ * Developer-facing input shape for filtering relationship tuples.
+ *
+ * Optional fields default to "any" when omitted: missing `relation` matches
+ * every relation, missing `subject` matches every subject, etc.
+ */
+export interface TupleFilterInput {
+  entity?: {
+    type: string;
+    ids?: string[];
+  };
+  relation?: string;
+  subject?: {
+    type: string;
+    ids?: string[];
+    relation?: string;
+  };
+}
+
+/**
+ * Normalizes a {@link TupleFilterInput} into the shape Permify's gRPC API
+ * expects (every field present, defaults filled in).
+ *
+ * Use this when calling {@link readRelationships} or {@link deleteRelationships}
+ * with a partial filter, or when constructing filters by hand.
+ *
+ * @example
+ * ```typescript
+ * const filter = tupleFilter({ entity: { type: "document" } });
+ * await deleteRelationships({ client, tenantId: "t1", filter });
+ * ```
+ */
+export function tupleFilter(input: TupleFilterInput = {}) {
+  return {
+    entity: {
+      type: input.entity?.type ?? "",
+      ids: input.entity?.ids ?? []
+    },
+    relation: input.relation ?? "",
+    subject: input.subject
+      ? {
+          type: input.subject.type,
+          ids: input.subject.ids ?? [],
+          relation: input.subject.relation ?? ""
+        }
+      : { type: "", ids: [], relation: "" }
+  };
+}

--- a/packages/core/src/data/write-relationships.ts
+++ b/packages/core/src/data/write-relationships.ts
@@ -1,3 +1,4 @@
+import { tupleFilter } from "./tuple-filter.js";
 import {
   BasePermifyWriter,
   type BaseWriteParams,
@@ -39,11 +40,20 @@ export interface Relationship {
   };
 }
 
-interface WriteRelationshipsParams extends BaseWriteParams {
+interface WriteRelationshipsParamsFlat extends BaseWriteParams {
+  tuples: Relationship[];
+}
+
+interface WriteRelationshipsParamsNested extends BaseWriteParams {
+  /** @deprecated Pass `tuples` directly at the top level. */
   relationships: {
     tuples: Relationship[];
   };
 }
+
+type WriteRelationshipsParams =
+  | WriteRelationshipsParamsFlat
+  | WriteRelationshipsParamsNested;
 
 interface WriteRelationshipsResult extends BaseWriterResult {
   success: boolean;
@@ -92,7 +102,8 @@ class RelationshipWriter extends BasePermifyWriter<
     client: any,
     params: WriteRelationshipsParams
   ): Promise<{ success: boolean; count: number }> {
-    const tuples = params.relationships.tuples;
+    const tuples =
+      "tuples" in params ? params.tuples : params.relationships.tuples;
 
     await client.data.write({
       tenantId: params.tenantId,
@@ -116,13 +127,12 @@ class RelationshipWriter extends BasePermifyWriter<
  * ```typescript
  * const res = await writeRelationships({
  *   tenantId: 'my-tenant',
- *   relationships: {
- *     tuples: [{
- *       entity: { type: 'document', id: '1' },
- *       relation: 'owner',
- *       subject: { type: 'user', id: 'user-1' },
- *     }]
- *   }
+ *   client,
+ *   tuples: [{
+ *     entity: { type: 'document', id: '1' },
+ *     relation: 'owner',
+ *     subject: { type: 'user', id: 'user-1' },
+ *   }]
  * });
  * ```
  */
@@ -143,7 +153,7 @@ class RelationshipDeleter extends BasePermifyWriter<
   ): Promise<{ success: boolean }> {
     await client.data.delete({
       tenantId: params.tenantId,
-      filter: params.filter
+      filter: tupleFilter(params.filter)
     });
 
     return { success: true };

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -63,15 +63,21 @@ function loadEnvFile(dir: string): void {
 export interface LoadConfigOptions {
   /** Skip schema validation — use for commands that don't require a schema (e.g. relationship export/list). */
   skipSchemaValidation?: boolean;
+  /** Directory to resolve the default config file from. Defaults to `process.cwd()`. */
+  cwd?: string;
 }
 
+/**
+ * @see {@link defineConfig} and {@link validateConfig} for an in-memory config
+ * path that does not touch the filesystem.
+ */
 export async function loadConfig(
   configFilePath?: string,
   options?: LoadConfigOptions
 ): Promise<PermifyConfigOptions> {
-  const cwd = process.cwd();
+  const cwd = options?.cwd ? path.resolve(options.cwd) : process.cwd();
   const configPath = configFilePath
-    ? path.resolve(configFilePath)
+    ? path.resolve(cwd, configFilePath)
     : path.join(cwd, DEFAULT_CONFIG_FILE);
 
   if (!fs.existsSync(configPath)) {

--- a/packages/core/src/public-api.ts
+++ b/packages/core/src/public-api.ts
@@ -57,6 +57,8 @@ export {
   type DeleteRelationshipsParams
 } from "./data/write-relationships.js";
 
+export { tupleFilter, type TupleFilterInput } from "./data/tuple-filter.js";
+
 export {
   readRelationships,
   type ReadRelationshipsParams

--- a/packages/core/tests/relationships.spec.ts
+++ b/packages/core/tests/relationships.spec.ts
@@ -1,0 +1,107 @@
+import "@japa/assert";
+
+import { test } from "@japa/runner";
+import {
+  writeRelationships,
+  deleteRelationships,
+  type Relationship
+} from "@permify-toolkit/core";
+
+interface FakeWriteCall {
+  tenantId: string;
+  tuples: Relationship[];
+}
+
+interface FakeDeleteCall {
+  tenantId: string;
+  filter: any;
+}
+
+function makeFakeClient() {
+  const writes: FakeWriteCall[] = [];
+  const deletes: FakeDeleteCall[] = [];
+  return {
+    writes,
+    deletes,
+    tenancy: {
+      list: async () => ({ tenants: [{ id: "t1" }] }),
+      create: async () => ({}),
+      delete: async () => ({})
+    },
+    data: {
+      write: async (req: any) => {
+        writes.push({ tenantId: req.tenantId, tuples: req.tuples });
+      },
+      delete: async (req: any) => {
+        deletes.push({ tenantId: req.tenantId, filter: req.filter });
+      }
+    }
+  };
+}
+
+const sampleTuple: Relationship = {
+  entity: { type: "document", id: "d1" },
+  relation: "owner",
+  subject: { type: "user", id: "u1" }
+};
+
+test.group("writeRelationships", () => {
+  test("accepts flat tuples shape", async ({ assert }) => {
+    const client = makeFakeClient();
+    const result = await writeRelationships({
+      client,
+      tenantId: "t1",
+      tuples: [sampleTuple]
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.count, 1);
+    assert.deepEqual(client.writes[0].tuples, [sampleTuple]);
+  });
+
+  test("still accepts nested relationships shape", async ({ assert }) => {
+    const client = makeFakeClient();
+    const result = await writeRelationships({
+      client,
+      tenantId: "t1",
+      relationships: { tuples: [sampleTuple] }
+    });
+    assert.equal(result.count, 1);
+  });
+
+  test("works without endpoint when client is provided", async ({ assert }) => {
+    const client = makeFakeClient();
+    const result = await writeRelationships({
+      client,
+      tenantId: "t1",
+      tuples: [sampleTuple]
+    });
+    assert.equal(result.success, true);
+  });
+});
+
+test.group("deleteRelationships", () => {
+  test("normalizes an empty filter to gRPC defaults", async ({ assert }) => {
+    const client = makeFakeClient();
+    await deleteRelationships({
+      client,
+      tenantId: "t1",
+      filter: {}
+    });
+    assert.deepEqual(client.deletes[0].filter, {
+      entity: { type: "", ids: [] },
+      relation: "",
+      subject: { type: "", ids: [], relation: "" }
+    });
+  });
+
+  test("normalizes a partial entity-only filter", async ({ assert }) => {
+    const client = makeFakeClient();
+    await deleteRelationships({
+      client,
+      tenantId: "t1",
+      filter: { entity: { type: "document" } }
+    });
+    assert.equal(client.deletes[0].filter.entity.type, "document");
+    assert.deepEqual(client.deletes[0].filter.entity.ids, []);
+  });
+});

--- a/packages/core/tests/tuple-filter.spec.ts
+++ b/packages/core/tests/tuple-filter.spec.ts
@@ -1,0 +1,35 @@
+import "@japa/assert";
+
+import { test } from "@japa/runner";
+import { tupleFilter } from "@permify-toolkit/core";
+
+test.group("tupleFilter", () => {
+  test("fills defaults for an empty input", ({ assert }) => {
+    assert.deepEqual(tupleFilter(), {
+      entity: { type: "", ids: [] },
+      relation: "",
+      subject: { type: "", ids: [], relation: "" }
+    });
+  });
+
+  test("preserves entity type and fills missing ids", ({ assert }) => {
+    assert.deepEqual(tupleFilter({ entity: { type: "document" } }), {
+      entity: { type: "document", ids: [] },
+      relation: "",
+      subject: { type: "", ids: [], relation: "" }
+    });
+  });
+
+  test("normalizes a partial subject filter", ({ assert }) => {
+    const out = tupleFilter({
+      entity: { type: "document", ids: ["d1"] },
+      relation: "viewer",
+      subject: { type: "user", ids: ["u1"] }
+    });
+    assert.deepEqual(out, {
+      entity: { type: "document", ids: ["d1"] },
+      relation: "viewer",
+      subject: { type: "user", ids: ["u1"], relation: "" }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Improves standalone developer experience for `@permify-toolkit/core` so it stops feeling like an internal SDK that only the `nestjs` and `cli` packages know how to use. Five focused, additive changes plus doc fixes:

- **`BaseWriteParams.endpoint` is now optional** when `client` is provided. Affects `writeSchemaToPermify`, `readSchemaFromPermify`, `writeRelationships`, `deleteRelationships`. Previously the type required `endpoint` even though runtime validation accepted either — the type lied.
- **`writeRelationships` accepts flat `tuples`** at the top level. The old nested `relationships: { tuples }` form still works but is JSDoc-deprecated. No consumer breakage.
- **New public helper `tupleFilter()`** (and `TupleFilterInput` type) for building Permify-shaped relationship filters from a partial input.
- **`deleteRelationships` now normalizes its `filter`** the same way `readRelationships` already did, via `tupleFilter()`. Partial filters like `{ entity: { type: "document" } }` no longer hit gRPC default-shape gaps.
- **`loadConfig` accepts a `cwd` option** so it can resolve the default config file from a directory other than `process.cwd()`.

Docs were also updated: new sections for `tupleFilter` and `loadConfig`, and three pre-existing example bugs were fixed (`checkPermission` returns a `boolean` not `{ allowed }`; `writeRelationships`/`deleteRelationships` are single-param, and the delete example used a non-existent `tuples` field instead of `filter`).

No breaking changes. Only `@permify-toolkit/core` is bumped (minor); cli and nestjs source is untouched and continues to work against the new core.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / chore

## Affected Package(s)

- [x] `@permify-toolkit/core`
- [ ] `@permify-toolkit/nestjs`
- [ ] `@permify-toolkit/cli`
- [x] Simulator / docs

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the existing style (ran `pnpm lint` and `pnpm format:check`)
- [x] Tests are passing (`pnpm test`)
- [x] I have added/updated tests for new behavior
- [x] I have run `pnpm changeset` if this change affects a published package
- [x] Public API changes are reflected in `src/public-api.ts`

## Related Issues

none
