### PR TITLE
Feat/permission result

### DIFF
--- a/.changeset/permission-result-decorator.md
+++ b/.changeset/permission-result-decorator.md
@@ -1,0 +1,5 @@
+---
+"@permify-toolkit/nestjs": minor
+---
+
+Add `@PermissionResult()` param decorator — injects guard-computed permission check results into handler parameters without a second gRPC round-trip.

--- a/docs-site/docs/packages/nestjs.md
+++ b/docs-site/docs/packages/nestjs.md
@@ -265,14 +265,67 @@ The `@CheckPermission` decorator supports multiple permissions:
 3. Passes `{ depth: 20 }` as default metadata if none is configured
 4. Throws `ForbiddenException` with a descriptive message on failure
 
+## Accessing Permission Results
+
+When a route has multiple permissions checked with OR mode, you often need to know _which_ ones passed, to conditionally include data, set flags, or write audit logs. `@PermissionResult()` injects the guard's results directly into the handler, with no second round-trip to Permify.
+
+```typescript
+import { Controller, Get, Param, UseGuards } from "@nestjs/common";
+import {
+  CheckPermission,
+  PermifyGuard,
+  PermissionResult,
+  type PermissionCheckResult
+} from "@permify-toolkit/nestjs";
+
+@Controller("documents")
+@UseGuards(PermifyGuard)
+export class DocumentsController {
+  @Get(":id")
+  @CheckPermission(["document.view", "document.edit"], { mode: "OR" })
+  async getDocument(
+    @Param("id") id: string,
+    @PermissionResult() permissions: PermissionCheckResult[]
+  ) {
+    const canEdit = permissions.find((p) => p.permission === "edit")?.allowed;
+
+    return {
+      document: await this.documentService.findOne(id),
+      editable: canEdit ?? false // surface to frontend — no second gRPC call
+    };
+  }
+}
+```
+
+`PermissionCheckResult` is:
+
+```typescript
+interface PermissionCheckResult {
+  permission: string; // e.g. "view", "edit"
+  allowed: boolean;
+}
+```
+
+:::info
+`@PermissionResult()` requires `PermifyGuard` to have already run on the route. It returns `[]` on public routes where no guard ran.
+:::
+
+**Common uses:**
+
+- OR-mode checks where you need to know which permission was granted (e.g. `admin` vs `editor` to shape the response)
+- Returning permission flags alongside resource data so the frontend doesn't need a separate permissions call
+- Audit logging which permissions were checked and what the outcome was
+
 ## API Reference
 
 ### Exports
 
-| Export                | Description                                          |
-| --------------------- | ---------------------------------------------------- |
-| `PermifyModule`       | NestJS dynamic module (`forRoot` / `forRootAsync`)   |
-| `PermifyService`      | Injectable service for manual permission checks      |
-| `PermifyGuard`        | Route guard implementing `CanActivate`               |
-| `@CheckPermission()`  | Decorator to specify required permissions            |
-| `@PermifyResolvers()` | Decorator to override resolvers per controller/route |
+| Export                  | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| `PermifyModule`         | NestJS dynamic module (`forRoot` / `forRootAsync`)   |
+| `PermifyService`        | Injectable service for manual permission checks      |
+| `PermifyGuard`          | Route guard implementing `CanActivate`               |
+| `@CheckPermission()`    | Decorator to specify required permissions            |
+| `@PermifyResolvers()`   | Decorator to override resolvers per controller/route |
+| `@PermissionResult()`   | Param decorator to inject guard's check results      |
+| `PermissionCheckResult` | Type for each entry in the results array             |

--- a/docs-site/docs/roadmap.md
+++ b/docs-site/docs/roadmap.md
@@ -16,7 +16,7 @@ What we've shipped and what's next.
 ## `@permify-toolkit/nestjs`
 
 - [x] Multi permission checks (AND + OR logic)
-- [ ] `@PermissionResult()` decorator to access check results inside handlers without re-checking
+- [x] `@PermissionResult()` decorator to access check results inside handlers without re-checking
 - [ ] Permission caching via NestJS `CacheModule`
 - [ ] Audit logging interceptor for permission check decisions
 - [ ] Typed entity and permission names from the schema DSL

--- a/packages/nestjs/src/constant.ts
+++ b/packages/nestjs/src/constant.ts
@@ -1,3 +1,5 @@
 export const PERMIFY_MODULE_OPTIONS = "PERMIFY_MODULE_OPTIONS";
 export const PERMIFY_RESOLVERS_KEY = "PERMIFY_RESOLVERS_KEY";
 export const PERMIFY_PERMISSION_KEY = "PERMIFY_PERMISSION_KEY";
+// Request property key (not a SetMetadata token) — colon-namespaced by NestJS convention.
+export const PERMIFY_RESULT_KEY = "permify:results";

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -1,6 +1,11 @@
-import { SetMetadata } from "@nestjs/common";
+import {
+  SetMetadata,
+  createParamDecorator,
+  type ExecutionContext
+} from "@nestjs/common";
 
-import { PERMIFY_PERMISSION_KEY } from "./constant.js";
+import type { PermissionCheckResult } from "./interfaces.js";
+import { PERMIFY_PERMISSION_KEY, PERMIFY_RESULT_KEY } from "./constant.js";
 
 /**
  * Defines the logical mode applied when multiple permissions are provided.
@@ -74,3 +79,27 @@ export const CheckPermission = (
     mode
   });
 };
+
+/**
+ * Parameter decorator that injects the permission check results computed by
+ * {@link PermifyGuard} into the handler method.
+ *
+ * Requires the guard to have already run for this route. Returns an empty
+ * array when no guard ran (public routes).
+ *
+ * @example
+ * ```typescript
+ * @UseGuards(PermifyGuard)
+ * @CheckPermission(['document.view', 'document.edit'], { mode: 'OR' })
+ * @Get(':id')
+ * async get(@PermissionResult() results: PermissionCheckResult[]) {
+ *   const canEdit = results.find(r => r.permission === 'edit')?.allowed;
+ * }
+ * ```
+ */
+export const PermissionResult = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): PermissionCheckResult[] =>
+    (ctx.switchToHttp().getRequest<Record<string, unknown>>()[
+      PERMIFY_RESULT_KEY
+    ] as PermissionCheckResult[] | undefined) ?? []
+);

--- a/packages/nestjs/src/guard.ts
+++ b/packages/nestjs/src/guard.ts
@@ -10,8 +10,8 @@ import {
 
 import { PermifyService } from "./service.js";
 import { PermissionModes } from "./decorators.js";
-import { PERMIFY_PERMISSION_KEY } from "./constant.js";
 import type { CheckPermissionMetadata } from "./interfaces.js";
+import { PERMIFY_PERMISSION_KEY, PERMIFY_RESULT_KEY } from "./constant.js";
 
 /**
  * Guard that enforces Permify permission checks.
@@ -130,6 +130,10 @@ export class PermifyGuard implements CanActivate {
         },
         checks
       });
+
+      context.switchToHttp().getRequest<Record<string, unknown>>()[
+        PERMIFY_RESULT_KEY
+      ] = results;
 
       if (permissionMeta.mode === PermissionModes.AND) {
         const failedCheck = results.find((r) => !r.allowed);

--- a/packages/nestjs/src/interfaces.ts
+++ b/packages/nestjs/src/interfaces.ts
@@ -20,6 +20,16 @@ export interface CheckPermissionMetadata {
 }
 
 /**
+ * Represents the outcome of a single permission check performed by the guard.
+ */
+export interface PermissionCheckResult {
+  /** The permission string that was evaluated (e.g. `"view"`, `"edit"`). */
+  permission: string;
+  /** Whether the subject was granted this permission. */
+  allowed: boolean;
+}
+
+/**
  * Represents a subject in the NestJS context (e.g. `user:1`).
  */
 export interface PermifySubject {

--- a/packages/nestjs/tests/decorators.spec.ts
+++ b/packages/nestjs/tests/decorators.spec.ts
@@ -1,9 +1,11 @@
 import "reflect-metadata";
 
 import { test } from "@japa/runner";
+import type { ExecutionContext } from "@nestjs/common";
 
-import { CheckPermission } from "../src/decorators.js";
-import { PERMIFY_PERMISSION_KEY } from "../src/constant.js";
+import type { PermissionCheckResult } from "../src/interfaces.js";
+import { CheckPermission, PermissionResult } from "../src/decorators.js";
+import { PERMIFY_PERMISSION_KEY, PERMIFY_RESULT_KEY } from "../src/constant.js";
 
 test.group("CheckPermission decorator", () => {
   const getMetadata = (target: any) =>
@@ -61,5 +63,63 @@ test.group("CheckPermission decorator", () => {
         method() {}
       }
     }, "Invalid permission mode 'INVALID'. Expected 'AND' or 'OR'.");
+  });
+});
+
+test.group("PermissionResult decorator", () => {
+  function makeCtx(request: Record<string, unknown>): ExecutionContext {
+    return {
+      switchToHttp: () => ({ getRequest: () => request })
+    } as unknown as ExecutionContext;
+  }
+
+  test("returns results stored on request", ({ assert }) => {
+    const stored: PermissionCheckResult[] = [
+      { permission: "view", allowed: true },
+      { permission: "edit", allowed: false }
+    ];
+    const mockRequest: Record<string, unknown> = {
+      [PERMIFY_RESULT_KEY]: stored
+    };
+    const ctx = makeCtx(mockRequest);
+
+    class C {
+      handler(@PermissionResult() _r: PermissionCheckResult[]) {}
+    }
+    const argsMetadata =
+      (Reflect.getMetadata("__routeArguments__", C, "handler") as Record<
+        string,
+        any
+      >) ?? {};
+    const factory = Object.values(argsMetadata)[0]?.factory;
+    assert.isFunction(
+      factory,
+      "Expected NestJS to register param decorator factory"
+    );
+
+    const result = factory(undefined, ctx) as PermissionCheckResult[];
+    assert.deepEqual(result, stored);
+  });
+
+  test("returns empty array when no guard ran", ({ assert }) => {
+    const mockRequest: Record<string, unknown> = {};
+    const ctx = makeCtx(mockRequest);
+
+    class C {
+      handler(@PermissionResult() _r: PermissionCheckResult[]) {}
+    }
+    const argsMetadata =
+      (Reflect.getMetadata("__routeArguments__", C, "handler") as Record<
+        string,
+        any
+      >) ?? {};
+    const factory = Object.values(argsMetadata)[0]?.factory;
+    assert.isFunction(
+      factory,
+      "Expected NestJS to register param decorator factory"
+    );
+
+    const result = factory(undefined, ctx) as PermissionCheckResult[];
+    assert.deepEqual(result, []);
   });
 });

--- a/packages/nestjs/tests/guard.spec.ts
+++ b/packages/nestjs/tests/guard.spec.ts
@@ -11,14 +11,17 @@ import {
 import { PermifyGuard } from "../src/guard.js";
 import { PermifyService } from "../src/service.js";
 import { CheckPermission } from "../src/decorators.js";
+import { PERMIFY_RESULT_KEY } from "../src/constant.js";
 
 function createMockContext(
   handler: ((...args: any[]) => any) | undefined,
-  cls: any
+  cls: any,
+  request: Record<string, unknown> = {}
 ): ExecutionContext {
   return {
     getHandler: () => handler,
-    getClass: () => cls
+    getClass: () => cls,
+    switchToHttp: () => ({ getRequest: () => request })
   } as unknown as ExecutionContext;
 }
 
@@ -646,5 +649,42 @@ test.group("PermifyGuard", (group) => {
       () => guard.canActivate(context),
       "Permission check execution failed"
     );
+  });
+
+  test("stores permission results on request after successful check", async ({
+    assert
+  }) => {
+    const mockRequest: Record<string, unknown> = {};
+
+    @Controller()
+    class TestController {
+      @CheckPermission("document.view")
+      @UseGuards(PermifyGuard)
+      @Get()
+      test() {}
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TestController],
+      providers: [
+        PermifyGuard,
+        Reflector,
+        { provide: PermifyService, useValue: mockPermifyService }
+      ]
+    }).compile();
+
+    const guard = moduleRef.get(PermifyGuard);
+    const context = createMockContext(
+      TestController.prototype.test,
+      TestController,
+      mockRequest
+    );
+
+    await guard.canActivate(context);
+
+    assert.isArray(mockRequest[PERMIFY_RESULT_KEY]);
+    assert.deepEqual(mockRequest[PERMIFY_RESULT_KEY], [
+      { permission: "view", allowed: true }
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds @PermissionResult(), a NestJS param decorator that injects the permission check results already computed by PermifyGuard into the handler method, no second gRPC round-trip needed. The guard stores its evaluatePermissions results on the HTTP request object; the decorator reads them. Useful for OR-mode routes where you need to know which specific permission passed, or for surfacing permission flags alongside resource data.

  Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Refactor / chore

  Affected Package(s) 

  - [ ] @permify-toolkit/core
  - [x] @permify-toolkit/nestjs
  - [ ] @permify-toolkit/cli
  - [x] Simulator / docs

  Checklist

  - [ ] I have read the Contributing Guidelines
  - [x] My code follows the existing style (ran pnpm lint and pnpm format:check)
  - [x] Tests are passing (pnpm test)
  - [x] I have added/updated tests for new behavior
  - [x] I have run pnpm changeset if this change affects a published package
  - [ ] Public API changes are reflected in src/public-api.ts

  Related Issues

none
