### PR TITLE
Feat(cli)/schema pull

### DIFF
--- a/.changeset/schema-pull-command.md
+++ b/.changeset/schema-pull-command.md
@@ -1,0 +1,5 @@
+---
+"@permify-toolkit/cli": minor
+---
+
+Add `schema pull` command — fetches the deployed schema from the Permify server and writes it to a local `.perm` file. Supports `--tenant`, `--output`, and `--force` (overwrite guard).

--- a/docs-site/docs/packages/cli.md
+++ b/docs-site/docs/packages/cli.md
@@ -216,6 +216,8 @@ permify-toolkit schema pull --tenant staging --output ./staging.perm
 permify-toolkit schema pull --force
 ```
 
+If the output file already exists, the command refuses to overwrite it and exits with an error. Pass `--force` to replace the existing file — useful when re-pulling a tenant into the same path.
+
 Pull from two environments and run `schema diff --source` between the files to compare them.
 
 #### `schema diff`

--- a/docs-site/docs/packages/cli.md
+++ b/docs-site/docs/packages/cli.md
@@ -187,6 +187,37 @@ permify-toolkit schema validate && permify-toolkit schema push
 Run `schema validate` before `schema push` for instant local feedback, no server connection needed.
 :::
 
+#### `schema pull`
+
+Fetches the schema currently deployed on the Permify server and writes it to a local `.perm` file. The inverse of `schema push` — useful for snapshotting a live tenant or bootstrapping a local schema from a running server.
+
+```bash
+permify-toolkit schema pull [--tenant <id>] [flags]
+```
+
+**Flags:**
+
+| Flag       | Alias | Description                            | Required | Default         |
+| ---------- | ----- | -------------------------------------- | -------- | --------------- |
+| `--tenant` |       | Tenant ID to pull from                 | No       | From config     |
+| `--output` | `-o`  | Path to write the pulled schema        | No       | `./schema.perm` |
+| `--force`  | `-f`  | Overwrite the output file if it exists | No       | `false`         |
+
+**Examples:**
+
+```bash
+# Pull the deployed schema into ./schema.perm
+permify-toolkit schema pull
+
+# Pull a specific tenant into a custom path
+permify-toolkit schema pull --tenant staging --output ./staging.perm
+
+# Overwrite an existing file
+permify-toolkit schema pull --force
+```
+
+Pull from two environments and run `schema diff --source` between the files to compare them.
+
 #### `schema diff`
 
 Previews what will change before pushing a schema update. Compares your local schema (from `permify.config.ts`) against the schema currently deployed on the Permify server — or against another local `.perm` file.

--- a/docs-site/docs/roadmap.md
+++ b/docs-site/docs/roadmap.md
@@ -27,7 +27,7 @@ What we've shipped and what's next.
 - [x] Schema validation
 - [x] Relationship queries (list, inspect, export)
 - [x] Schema diff
-- [ ] Schema pull
+- [x] Schema pull
 - [ ] Permission check from the terminal
 - [ ] Relationship deletion (individual + bulk clear)
 - [ ] Init command to scaffold `permify.config.ts`

--- a/docs/schema-pull-plan.md
+++ b/docs/schema-pull-plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: `schema pull`
+
+**Goal:** Add `permify-toolkit schema pull` to the CLI — fetch the live schema from
+the Permify server for a tenant and write it to a local `.perm` file.
+
+**Why next:** Completes the schema workflow loop. We can already `push`, `validate`,
+and `diff` against remote; `pull` is the inverse of `push` and lets users snapshot
+or bootstrap a local schema from a running server. The reconstruction work is
+already done — `readSchemaFromPermify` (core) returns a ready DSL string.
+
+## What already exists (no new core work)
+
+- `readSchemaFromPermify({ tenantId, client })` → `{ schema: string | null, entities }`
+  - Already exported from `@permify-toolkit/core/public-api`.
+  - Already used by `schema diff`. We reuse it as-is.
+- `BaseCommand.clientFromConfigLite()` — client + config without requiring a local
+  `schema` in config (correct here: pull doesn't need a local schema to exist).
+- `BaseCommand.resolveTenant(flags, config)` — tenant resolution + error.
+
+## Scope
+
+One new command file + one test + one docs section. No core changes, no new deps,
+no changeset for core. CLI gets a `minor` changeset (new public command).
+
+## Steps
+
+### 1. Command — `packages/cli/src/commands/schema/pull.ts` → verify: `pnpm build` passes
+
+Mirror `push.ts` structure. Flags:
+
+- `...BaseCommand.baseFlags` (gives `--tenant`)
+- `--output, -o` (string, default `./schema.perm`) — destination file path
+- `--force, -f` (boolean, default false) — overwrite if the file exists
+
+Logic:
+
+1. `const { client, config } = await this.clientFromConfigLite()` — no local schema needed.
+2. `const tenantId = this.resolveTenant(flags, config)`.
+3. `const { schema } = await readSchemaFromPermify({ tenantId, client })`.
+4. If `schema === null` → `this.error("No schema found on remote for tenant: <id>")`.
+5. Resolve output path. If it exists and `!flags.force` → `this.error(...)` telling
+   the user to pass `--force`. (Guard against silent overwrite — this is a write
+   boundary.)
+6. `fs.writeFileSync(outPath, schema, "utf-8")`.
+7. `this.log("✔ Schema pulled → <path> (tenant: <id>)")`.
+
+Keep it ~40 lines, matching `push.ts`. No reformatting of remote output beyond what
+core already reconstructs.
+
+> ponytail: not adding `--stdout`, `--format json`, or merge-into-config options.
+> Add `--stdout` only if someone asks to pipe it.
+
+### 2. Test — `packages/cli/tests/schema-pull.spec.ts` → verify: `pnpm test` passes
+
+Follow `schema-push.spec.ts` patterns (japa, `runCommand`, `fs` fixture). Cover:
+
+- Fails when no tenant (flag or config) → asserts "Tenant ID is required".
+- Fails on missing `permify.config.ts`.
+- Refuses to overwrite an existing output file without `--force` → asserts the
+  overwrite guard message (this is the one branch worth pinning down).
+- Attempts connection when config + tenant present (fails on connection, like the
+  push test does) — confirms it gets past arg/config validation.
+
+> Real-server happy path isn't unit-testable here (no live Permify), same as push.
+> The overwrite guard is the non-trivial branch, so it gets explicit coverage.
+
+### 3. Docs — `docs-site/docs/packages/cli.md` → verify: section renders
+
+Add a `#### \`schema pull\``section under`### Schema`, right after `schema push`
+(it's the push inverse). Include: synopsis, flags table (`--tenant`, `--output`,
+`--force`), 2–3 examples (default, custom output, force overwrite), and a one-line
+note: pull then diff to compare environments.
+
+### 4. Roadmap → verify: box checked
+
+Tick `- [ ] Schema pull` → `- [x] Schema pull` in `docs-site/docs/roadmap.md`.
+
+### 5. Changeset → verify: file created under `.changeset/`
+
+`pnpm changeset` — `@permify-toolkit/cli` **minor**, message: "Add `schema pull`
+command to fetch remote schema into a local .perm file."
+
+## Out of scope (say so, don't build)
+
+- `--stdout` / piping — add when requested.
+- Pulling into the AST/inline config form — remote → DSL string only.
+- Schema version selection (pull a specific historical version) — that's the separate
+  "Schema version history" roadmap item.
+
+## Done when
+
+`pnpm build && pnpm test && pnpm lint && pnpm format:check` all pass, docs + roadmap
+updated, changeset present.

--- a/packages/cli/permify.config.ts
+++ b/packages/cli/permify.config.ts
@@ -7,7 +7,7 @@ import {
 } from "@permify-toolkit/core";
 
 export default defineConfig({
-  tenant: "toolkit-test",
+  tenant: "phygitalmax",
   client: {
     endpoint: "localhost:3478",
     insecure: true

--- a/packages/cli/permify.config.ts
+++ b/packages/cli/permify.config.ts
@@ -7,10 +7,13 @@ import {
 } from "@permify-toolkit/core";
 
 export default defineConfig({
-  tenant: "phygitalmax",
+  tenant: "test",
   client: {
     endpoint: "localhost:3478",
-    insecure: true
+    insecure: true,
+    interceptor: {
+      authToken: process.env.PERMIFY_AUTH_TOKEN || "abcd"
+    }
   },
   schema: schema({
     user: entity({

--- a/packages/cli/src/commands/schema/pull.ts
+++ b/packages/cli/src/commands/schema/pull.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Flags } from "@oclif/core";
+import { readSchemaFromPermify } from "@permify-toolkit/core";
+
+import { BaseCommand } from "../../base.js";
+
+export default class SchemaPull extends BaseCommand {
+  static description =
+    "Pull the deployed schema from the server into a local .perm file";
+
+  static args = {};
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    output: Flags.string({
+      char: "o",
+      description: "Path to write the pulled schema",
+      default: "./schema.perm"
+    }),
+    force: Flags.boolean({
+      char: "f",
+      description: "Overwrite the output file if it already exists",
+      default: false
+    })
+  };
+
+  async run() {
+    const { flags } = await this.parse(SchemaPull);
+
+    const { client, config } = await this.clientFromConfigLite();
+    const tenantId = this.resolveTenant(flags, config);
+
+    const outPath = path.resolve(flags.output);
+    if (fs.existsSync(outPath) && !flags.force) {
+      this.error(
+        `File already exists: ${outPath}\nPass --force to overwrite it.`
+      );
+    }
+
+    const { schema } = await readSchemaFromPermify({ tenantId, client });
+    if (schema === null) {
+      this.error(`No schema found on remote for tenant: ${tenantId}`);
+    }
+
+    fs.writeFileSync(outPath, schema, "utf-8");
+
+    this.log(`✔ Schema pulled → ${flags.output} (tenant: ${tenantId})`);
+  }
+}

--- a/packages/cli/tests/schema-pull.spec.ts
+++ b/packages/cli/tests/schema-pull.spec.ts
@@ -1,0 +1,82 @@
+import "@japa/assert";
+import "@japa/file-system";
+
+import { test } from "@japa/runner";
+
+import { runCommand, stripAnsi } from "./helpers.js";
+import SchemaPull from "../src/commands/schema/pull.js";
+
+const config = `
+  export default {
+    client: { endpoint: "localhost:11111", insecure: true },
+  };
+`;
+
+const configWithTenant = `
+  export default {
+    tenant: "config-tenant",
+    client: { endpoint: "localhost:11111", insecure: true },
+  };
+`;
+
+test.group("Schema Pull Command", () => {
+  test("should fail if no tenant is provided (flag or config)", async ({
+    assert,
+    fs
+  }) => {
+    await fs.create("permify.config.ts", config);
+
+    const cwd = fs.basePath;
+    try {
+      await runCommand(SchemaPull as any, [], { cwd });
+      assert.fail("Command should have failed");
+    } catch (error: any) {
+      assert.include(stripAnsi(error.message), "Tenant ID is required");
+    }
+  });
+
+  test("should fail if permify.config.ts is missing in cwd", async ({
+    assert,
+    fs
+  }) => {
+    await fs.create("dummy", "");
+    const cwd = fs.basePath;
+    try {
+      await runCommand(SchemaPull as any, ["--tenant=t1"], { cwd });
+      assert.fail("Command should have failed");
+    } catch (error: any) {
+      assert.exists(error);
+    }
+  });
+
+  test("should refuse to overwrite an existing output file without --force", async ({
+    assert,
+    fs
+  }) => {
+    await fs.create("permify.config.ts", config);
+    await fs.create("schema.perm", "entity user {}");
+
+    const cwd = fs.basePath;
+    try {
+      await runCommand(SchemaPull as any, ["--tenant=t1"], { cwd });
+      assert.fail("Command should have failed");
+    } catch (error: any) {
+      assert.include(stripAnsi(error.message), "Pass --force to overwrite");
+    }
+  });
+
+  test("should resolve tenant from config and attempt connection", async ({
+    assert,
+    fs
+  }) => {
+    await fs.create("permify.config.ts", configWithTenant);
+
+    const cwd = fs.basePath;
+    try {
+      await runCommand(SchemaPull as any, [], { cwd });
+      assert.fail("Command should have failed due to connection");
+    } catch (error: any) {
+      assert.notInclude(stripAnsi(error.message), "Tenant ID is required");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

  Adds a `schema pull` command to `@permify-toolkit/cli` that fetches the schema
  currently deployed on the Permify server and writes it to a local `.perm` file.

  It's the inverse of `schema push`, useful for snapshotting a live tenant or
  bootstrapping a local schema from a running server. No new core work was needed;
  the command reuses the existing `readSchemaFromPermify` helper (already used by
  `schema diff`).

  **Behavior**
  - `permify-toolkit schema pull` → writes to `./schema.perm`
  - `--output, -o` to choose the destination path
  - `--tenant` resolved from flag or config (standard `BaseCommand` behavior)
  - Refuses to overwrite an existing file unless `--force, -f` is passed (overwrite guard runs before the network call, so it fails fast)
  - Errors clearly if no schema exists on the remote for the tenant

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Refactor / chore

  ## Affected Package(s)

  - [ ] `@permify-toolkit/core`
  - [ ] `@permify-toolkit/nestjs`
  - [x] `@permify-toolkit/cli`
  - [x] Simulator / docs

  ## Checklist

  - [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
  - [x] My code follows the existing style (ran `pnpm lint` and `pnpm format:check`)
  - [x] Tests are passing (`pnpm test`)
  - [x] I have added/updated tests for new behavior
  - [x] I have run `pnpm changeset` if this change affects a published package
  - [ ] Public API changes are reflected in `src/public-api.ts` — N/A (CLI commands aren't exported via `public-api.ts`; no core surface changed)