### PR TITLE
feat: add init command to scaffold permify.config.ts with configurabl…

### DIFF
--- a/.changeset/init-command.md
+++ b/.changeset/init-command.md
@@ -1,0 +1,5 @@
+---
+"@permify-toolkit/cli": minor
+---
+
+Add `init` command — scaffolds a starter `permify.config.ts` with a minimal valid example schema. Supports `--tenant` and `--endpoint`; refuses to overwrite an existing config.

--- a/docs-site/docs/packages/cli.md
+++ b/docs-site/docs/packages/cli.md
@@ -89,6 +89,29 @@ The `--tenant` flag is **optional** if `tenant` is defined in `permify.config.ts
 
 ## Commands
 
+### `init`
+
+Scaffolds a starter `permify.config.ts` in the current directory — the first command to run in a new project. The generated config includes a minimal, valid example schema, so you can immediately run `schema validate` and `schema push`.
+
+```bash
+permify-toolkit init [flags]
+```
+
+**Flags:**
+
+| Flag         | Alias | Description                          | Required | Default          |
+| ------------ | ----- | ------------------------------------ | -------- | ---------------- |
+| `--tenant`   | `-t`  | Tenant ID to prefill into the config | No       | `t1`             |
+| `--endpoint` | `-e`  | Permify server endpoint to prefill   | No       | `localhost:3478` |
+
+**Example:**
+
+```bash
+permify-toolkit init --tenant my-app --endpoint localhost:3478
+```
+
+If `permify.config.ts` already exists, `init` refuses to overwrite it, delete the file first if you want to re-scaffold. After running it, edit the schema to fit your domain and run `permify-toolkit schema push` to deploy.
+
 ### Schema
 
 #### `schema push`

--- a/docs-site/docs/roadmap.md
+++ b/docs-site/docs/roadmap.md
@@ -30,7 +30,7 @@ What we've shipped and what's next.
 - [x] Schema pull
 - [ ] Permission check from the terminal
 - [ ] Relationship deletion (individual + bulk clear)
-- [ ] Init command to scaffold `permify.config.ts`
+- [x] Init command to scaffold `permify.config.ts`
 - [ ] Schema version history
 - [ ] Config validation (connection + schema syntax)
 - [ ] Multi-tenant management (create, list, delete tenants)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Command, Flags } from "@oclif/core";
+
+const template = (tenant: string, endpoint: string) => `import {
+  defineConfig,
+  schema,
+  entity,
+  relation,
+  permission
+} from "@permify-toolkit/core";
+
+export default defineConfig({
+  tenant: "${tenant}",
+  client: {
+    endpoint: "${endpoint}",
+    insecure: true,
+    interceptor: {
+      authToken: process.env.PERMIFY_AUTH_TOKEN
+    }
+  },
+  schema: schema({
+    user: entity({}),
+    document: entity({
+      relations: {
+        owner: relation("user"),
+        viewer: relation("user")
+      },
+      permissions: {
+        view: permission("viewer or owner"),
+        edit: permission("owner")
+      }
+    })
+  })
+});
+`;
+
+export default class Init extends Command {
+  static description =
+    "Scaffold a starter permify.config.ts in the current directory";
+
+  static args = {};
+
+  static flags = {
+    tenant: Flags.string({
+      char: "t",
+      description: "Tenant ID to prefill into the config",
+      default: "t1"
+    }),
+    endpoint: Flags.string({
+      char: "e",
+      description: "Permify server endpoint to prefill into the config",
+      default: "localhost:3478"
+    })
+  };
+
+  async run() {
+    const { flags } = await this.parse(Init);
+
+    const outPath = path.resolve("permify.config.ts");
+    if (fs.existsSync(outPath)) {
+      this.error("permify.config.ts already exists. Delete it to re-scaffold.");
+    }
+
+    fs.writeFileSync(outPath, template(flags.tenant, flags.endpoint), "utf-8");
+
+    this.log(`✔ Created permify.config.ts (tenant: ${flags.tenant})`);
+    this.log("Next: run `permify-toolkit schema push` to deploy your schema.");
+    this.log(
+      "If your server needs auth, set PERMIFY_AUTH_TOKEN in your environment."
+    );
+  }
+}

--- a/packages/cli/tests/init.spec.ts
+++ b/packages/cli/tests/init.spec.ts
@@ -1,0 +1,47 @@
+import "@japa/assert";
+import "@japa/file-system";
+
+import { test } from "@japa/runner";
+
+import Init from "../src/commands/init.js";
+import { runCommand, stripAnsi } from "./helpers.js";
+
+test.group("Init Command", () => {
+  test("should scaffold permify.config.ts with the given tenant and endpoint", async ({
+    assert,
+    fs
+  }) => {
+    // Ensure the temp dir exists before the command chdir's into it
+    await fs.create(".keep", "");
+
+    const cwd = fs.basePath;
+    await runCommand(Init as any, ["--tenant=acme", "--endpoint=remote:9999"], {
+      cwd
+    });
+
+    const exists = await fs.exists("permify.config.ts");
+    assert.isTrue(exists);
+
+    const content = await fs.contents("permify.config.ts");
+    assert.include(content, 'tenant: "acme"');
+    assert.include(content, 'endpoint: "remote:9999"');
+  });
+
+  test("should refuse when permify.config.ts already exists and leave it untouched", async ({
+    assert,
+    fs
+  }) => {
+    await fs.create("permify.config.ts", "ORIGINAL CONTENT");
+
+    const cwd = fs.basePath;
+    try {
+      await runCommand(Init as any, [], { cwd });
+      assert.fail("Command should have failed");
+    } catch (error: any) {
+      assert.include(stripAnsi(error.message), "already exists");
+    }
+
+    const content = await fs.contents("permify.config.ts");
+    assert.equal(content, "ORIGINAL CONTENT");
+  });
+});


### PR DESCRIPTION
## Summary

  Adds a `permify-toolkit init` command that scaffolds a starter `permify.config.ts`
  in the current directory, the first command a new user runs (think `prisma init`).

  The generated config includes a minimal, **valid** example schema (a `user` and a
  `document` entity with `view`/`edit` permissions), so a fresh project can immediately
  run `schema validate` and `schema push` and have it work.

  **Behavior**
  - `permify-toolkit init` → writes `permify.config.ts` to the current directory
  - `--tenant, -t` (default `t1`) and `--endpoint, -e` (default `localhost:3478`) prefill the scaffold
  - Refuses if `permify.config.ts` already exists, no `--force` flag, matching the convention of config scaffolders (prisma, tsc, cargo). A config is a file the user owns and edits; silently clobbering it is a footgun. Delete the file to re-scaffold.
  - No server connection, no config loading (it *creates* the config), no new dependencies

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Refactor / chore

  ## Affected Package(s)

  - [ ] `@permify-toolkit/core`
  - [ ] `@permify-toolkit/nestjs`
  - [x] `@permify-toolkit/cli`
  - [x] Simulator / docs

  ## Checklist

  - [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
  - [x] My code follows the existing style (ran `pnpm lint` and `pnpm format:check`)
  - [x] Tests are passing (`pnpm test`)
  - [x] I have added/updated tests for new behavior
  - [x] I have run `pnpm changeset` if this change affects a published package
  - [ ] Public API changes are reflected in `src/public-api.ts` — N/A (CLI commands are discovered by oclif, not exported; no core surface changed)

  ## Related Issues

none
