### PR TITLE
Feat/typed permission names

### DIFF
--- a/.changeset/typed-check-permission.md
+++ b/.changeset/typed-check-permission.md
@@ -1,0 +1,9 @@
+---
+"@permify-toolkit/core": minor
+"@permify-toolkit/nestjs": minor
+---
+
+Add typed entity and permission names from the schema DSL.
+
+- `core`: `entity()` now preserves the literal relation and permission keys of its definition, and a new `PermissionName<H>` type derives the union of a schema's checkable identifiers (qualified `"document.view"` and bare `"view"`, covering permissions and relations).
+- `nestjs`: new `createPermifyDecorators<typeof schema>()` returns a `CheckPermission` decorator constrained to that schema's names — invalid names are a compile error with editor autocomplete. The untyped `CheckPermission` is unchanged for `.perm`-file users.

--- a/docs-site/docs/packages/core.md
+++ b/docs-site/docs/packages/core.md
@@ -49,6 +49,18 @@ const mySchema = schema({
 
 This gives you compile-time safety — referencing a non-existent entity or relation is a type error.
 
+The `PermissionName` type extracts every checkable identifier from a schema, i.e., permissions and relations, in qualified and bare form:
+
+```typescript
+import type { PermissionName } from "@permify-toolkit/core";
+
+type Names = PermissionName<typeof mySchema>;
+// "document.edit" | "document.view" | "document.owner" | "document.editor"
+// | "edit" | "view" | "owner" | "editor"
+```
+
+This powers typed decorators in `@permify-toolkit/nestjs` (see [Typed Permission Names](./nestjs.md#typed-permission-names)) and can constrain your own helpers.
+
 ## Client Utilities
 
 ### Creating a Client
@@ -387,6 +399,7 @@ If you already have an in-memory config object (e.g. from a test fixture), skip 
 | `deleteRelationships()`   | Delete relationship tuples by filter                                                                    |
 | `tupleFilter()`           | Build a normalized relationship filter (fills gRPC defaults for omitted fields)                         |
 | `relationsOf()`           | Helper to extract relations from schema                                                                 |
+| `PermissionName`          | Type union of all permission/relation names in a schema (qualified and bare)                            |
 | `getSchemaWarnings()`     | Collect non-blocking warnings from a schema AST (unused relations, empty entities, missing permissions) |
 | `readSchemaFromPermify()` | Read the current schema from a Permify server for a given tenant                                        |
 | `diffSchema()`            | Compute a structural diff between two schema entity maps                                                |

--- a/docs-site/docs/packages/nestjs.md
+++ b/docs-site/docs/packages/nestjs.md
@@ -22,6 +22,7 @@ pnpm add @permify-toolkit/nestjs @permify-toolkit/core
 - **Optional Tenant Resolver** — set a static tenant in config, no resolver needed
 - **Authorization Guard** — `PermifyGuard` enforces permissions on routes
 - **Multi-Permission Checks** — AND/OR logic for complex authorization
+- **Typed Permission Names** — bind `@CheckPermission` to your schema DSL so invalid names fail at compile time
 
 ## Module Setup
 
@@ -258,6 +259,33 @@ The `@CheckPermission` decorator supports multiple permissions:
 @CheckPermission(["document.view", "document.edit"], { mode: "OR" })
 ```
 
+### Typed Permission Names
+
+`@CheckPermission` accepts any string. If your schema is defined with the core DSL (see [`schema()`](./core.md#type-safe-schema-dsl)), you can bind the decorator to it with `createPermifyDecorators` — then only names that exist in the schema compile, and your editor autocompletes them.
+
+```typescript
+// auth.ts — bind once, re-export
+import { createPermifyDecorators } from "@permify-toolkit/nestjs";
+import { appSchema } from "./permify.config";
+
+export const { CheckPermission } = createPermifyDecorators<typeof appSchema>();
+```
+
+```typescript
+// documents.controller.ts
+import { CheckPermission } from "./auth";
+
+@CheckPermission("document.edit")               // ✅ compiles
+@CheckPermission(["document.view", "edit"])     // ✅ qualified and bare forms both work
+@CheckPermission("document.rename")             // ❌ compile error — not in the schema
+```
+
+Both permissions and relations are accepted, in qualified (`"document.edit"`) and bare (`"edit"`) form the same set the guard resolves at runtime. Options like `{ mode: "OR" }` work identically to the untyped decorator.
+
+:::info
+Typed names require a DSL-defined schema. If you use `schemaFile()` with a `.perm` file, keep using the untyped `@CheckPermission` or mirror the schema in the DSL to get typing (see the [simulator](https://github.com/thisisnkc/permify-toolkit/blob/main/simulator/backend/src/auth.ts) for an example).
+:::
+
 ### How the Guard Works
 
 1. Resolves **Tenant**, **Subject**, and **Resource** from configured resolvers
@@ -320,12 +348,13 @@ interface PermissionCheckResult {
 
 ### Exports
 
-| Export                  | Description                                          |
-| ----------------------- | ---------------------------------------------------- |
-| `PermifyModule`         | NestJS dynamic module (`forRoot` / `forRootAsync`)   |
-| `PermifyService`        | Injectable service for manual permission checks      |
-| `PermifyGuard`          | Route guard implementing `CanActivate`               |
-| `@CheckPermission()`    | Decorator to specify required permissions            |
-| `@PermifyResolvers()`   | Decorator to override resolvers per controller/route |
-| `@PermissionResult()`   | Param decorator to inject guard's check results      |
-| `PermissionCheckResult` | Type for each entry in the results array             |
+| Export                      | Description                                                       |
+| --------------------------- | ----------------------------------------------------------------- |
+| `PermifyModule`             | NestJS dynamic module (`forRoot` / `forRootAsync`)                |
+| `PermifyService`            | Injectable service for manual permission checks                   |
+| `PermifyGuard`              | Route guard implementing `CanActivate`                            |
+| `@CheckPermission()`        | Decorator to specify required permissions                         |
+| `@PermifyResolvers()`       | Decorator to override resolvers per controller/route              |
+| `@PermissionResult()`       | Param decorator to inject guard's check results                   |
+| `PermissionCheckResult`     | Type for each entry in the results array                          |
+| `createPermifyDecorators()` | Create a `@CheckPermission` typed against a schema DSL definition |

--- a/docs-site/docs/roadmap.md
+++ b/docs-site/docs/roadmap.md
@@ -19,7 +19,7 @@ What we've shipped and what's next.
 - [x] `@PermissionResult()` decorator to access check results inside handlers without re-checking
 - [ ] Permission caching via NestJS `CacheModule`
 - [ ] Audit logging interceptor for permission check decisions
-- [ ] Typed entity and permission names from the schema DSL
+- [x] Typed entity and permission names from the schema DSL
 - [ ] WebSocket gateway support
 
 ## `@permify-toolkit/cli`

--- a/packages/core/src/public-api.ts
+++ b/packages/core/src/public-api.ts
@@ -10,7 +10,8 @@ export {
   type EntityDef,
   type RelationDef,
   type AttributeDef,
-  type PermissionDef
+  type PermissionDef,
+  type PermissionName
 } from "./schema/define-schema.js";
 
 export { relationsOf } from "./schema/helpers.js";

--- a/packages/core/src/schema/define-schema.ts
+++ b/packages/core/src/schema/define-schema.ts
@@ -63,7 +63,7 @@ export interface EntityDef {
  * })
  * ```
  */
-export function entity(def: EntityDef): EntityDef {
+export function entity<T extends EntityDef>(def: T): T {
   return def;
 }
 
@@ -176,6 +176,48 @@ export type PermissionProxy<TInput extends SchemaInput> = {
     ? { [Permission in keyof P & string]: `${Entity & string}:${Permission}` }
     : Record<string, never>;
 };
+
+/**
+ * Every checkable identifier for one entity: the names of its permissions
+ * and its relations. The guard treats both as checkable.
+ */
+type CheckableKeys<E> =
+  | (E extends { permissions: infer P } ? keyof P & string : never)
+  | (E extends { relations: infer R } ? keyof R & string : never);
+
+/** Qualified `"entity.name"` form, e.g. `"document.view"`. */
+type QualifiedName<T extends SchemaInput> = {
+  [Entity in keyof T & string]: `${Entity}.${CheckableKeys<T[Entity]>}`;
+}[keyof T & string];
+
+/** Bare `"name"` form (union across all entities), e.g. `"view"`. */
+type BareName<T extends SchemaInput> = {
+  [Entity in keyof T & string]: CheckableKeys<T[Entity]>;
+}[keyof T & string];
+
+/**
+ * Union of every identifier a schema exposes to a permission check, in both
+ * qualified (`"document.view"`) and bare (`"view"`) form, covering permissions
+ * and relations alike.
+ *
+ * This mirrors exactly what {@link https://permify.co Permify} guards accept at
+ * runtime, so it can constrain a typed `@CheckPermission()` decorator.
+ *
+ * @example
+ * ```ts
+ * const appSchema = schema({
+ *   document: entity({
+ *     relations: { owner: relation('user') },
+ *     permissions: { view: permission('owner') }
+ *   })
+ * })
+ *
+ * type Names = PermissionName<typeof appSchema>
+ * // "document.view" | "document.owner" | "view" | "owner"
+ * ```
+ */
+export type PermissionName<H extends SchemaHandle> =
+  H extends SchemaHandle<infer T> ? QualifiedName<T> | BareName<T> : never;
 
 /**
  * Defines a Permify authorization schema.

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "test": "NODE_NO_WARNINGS=1 pnpm exec tsx ../../tests/setup.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsup",
     "lint": "eslint 'src/**/*.ts' 'tests/**/*.ts' --fix"
   },

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -3,3 +3,4 @@ export * from "./service.js";
 export * from "./interfaces.js";
 export * from "./guard.js";
 export * from "./decorators.js";
+export * from "./typed-decorators.js";

--- a/packages/nestjs/src/typed-decorators.ts
+++ b/packages/nestjs/src/typed-decorators.ts
@@ -1,0 +1,38 @@
+import type { SchemaHandle, PermissionName } from "@permify-toolkit/core";
+
+import { CheckPermission, type CheckPermissionOptions } from "./decorators.js";
+
+/**
+ * Creates decorators typed against a specific schema.
+ *
+ * The returned `CheckPermission` behaves identically to the base decorator but
+ * only accepts identifiers that exist in the given schema — both qualified
+ * (`"document.view"`) and bare (`"view"`) forms. Invalid names are a compile
+ * error, and editors autocomplete the valid ones.
+ *
+ * Bind it once to your schema and re-export it from your auth module.
+ *
+ * @example
+ * ```typescript
+ * // auth.ts
+ * import { createPermifyDecorators } from '@permify-toolkit/nestjs';
+ * import { appSchema } from './permify.config';
+ *
+ * export const { CheckPermission } =
+ *   createPermifyDecorators<typeof appSchema>();
+ *
+ * // controller.ts
+ * @CheckPermission('document.edit') // OK
+ * @CheckPermission('document.xyz')  // compile error
+ * ```
+ */
+export function createPermifyDecorators<H extends SchemaHandle>() {
+  type Name = PermissionName<H>;
+
+  return {
+    CheckPermission: (
+      permissions: Name | Name[],
+      options?: CheckPermissionOptions
+    ) => CheckPermission(permissions, options)
+  };
+}

--- a/packages/nestjs/tests/typed-decorators.spec.ts
+++ b/packages/nestjs/tests/typed-decorators.spec.ts
@@ -1,0 +1,76 @@
+import "reflect-metadata";
+
+import { test } from "@japa/runner";
+import { schema, entity, relation, permission } from "@permify-toolkit/core";
+
+import { PERMIFY_PERMISSION_KEY } from "../src/constant.js";
+import { createPermifyDecorators } from "../src/typed-decorators.js";
+
+const _appSchema = schema({
+  user: entity({}),
+  document: entity({
+    relations: { owner: relation("user") },
+    permissions: { view: permission("owner"), edit: permission("owner") }
+  })
+});
+
+const { CheckPermission } = createPermifyDecorators<typeof _appSchema>();
+
+const getMetadata = (target: object) =>
+  Reflect.getMetadata(PERMIFY_PERMISSION_KEY, target);
+
+test.group("createPermifyDecorators", () => {
+  test("delegates single permission to base decorator", ({ assert }) => {
+    class TestClass {
+      @CheckPermission("document.edit")
+      method() {}
+    }
+
+    const metadata = getMetadata(TestClass.prototype.method);
+    assert.deepEqual(metadata.permissions, ["document.edit"]);
+    assert.equal(metadata.mode, "AND");
+  });
+
+  test("delegates array with OR mode", ({ assert }) => {
+    class TestClass {
+      @CheckPermission(["document.view", "document.edit"], { mode: "OR" })
+      method() {}
+    }
+
+    const metadata = getMetadata(TestClass.prototype.method);
+    assert.deepEqual(metadata.permissions, ["document.view", "document.edit"]);
+    assert.equal(metadata.mode, "OR");
+  });
+
+  test("accepts bare and relation names", ({ assert }) => {
+    class TestClass {
+      @CheckPermission(["view", "owner"])
+      method() {}
+    }
+
+    const metadata = getMetadata(TestClass.prototype.method);
+    assert.deepEqual(metadata.permissions, ["view", "owner"]);
+  });
+
+  /**
+   * Compile-time guarantees. These assertions are enforced by `tsc`
+   * (`pnpm typecheck`), not at runtime, so the test body is trivial.
+   */
+  test("rejects names absent from the schema", ({ assert }) => {
+    class TestClass {
+      // @ts-expect-error "document.xyz" is not a valid permission
+      @CheckPermission("document.xyz")
+      a() {}
+
+      // @ts-expect-error "invoice" entity does not exist
+      @CheckPermission("invoice.view")
+      b() {}
+
+      // @ts-expect-error "delete" is not a name in the schema
+      @CheckPermission(["view", "delete"])
+      c() {}
+    }
+
+    assert.isFunction(TestClass.prototype.a);
+  });
+});

--- a/simulator/backend/README.md
+++ b/simulator/backend/README.md
@@ -7,6 +7,8 @@ This is a sample NestJS application used to demonstrate and test the integration
 - Integrates `@permify-toolkit/nestjs` for authorization.
 - Uses `@permify-toolkit/cli` for schema management.
 - Local development setup for Permify.
+- Typed `@CheckPermission` bound to the schema DSL — see `src/auth.ts`.
+- `@PermissionResult()` to read guard check results inside a handler — see `src/documents.controller.ts`.
 
 ## Getting Started
 

--- a/simulator/backend/src/auth.ts
+++ b/simulator/backend/src/auth.ts
@@ -1,0 +1,35 @@
+import { schema, entity, relation, permission } from '@permify-toolkit/core';
+import { createPermifyDecorators } from '@permify-toolkit/nestjs';
+
+/**
+ * DSL mirror of test-schema.perm. Defining the schema in TypeScript lets
+ * createPermifyDecorators derive the set of valid permission names, so
+ * typos in @CheckPermission become compile errors instead of runtime 403s.
+ */
+export const appSchema = schema({
+  user: entity({}),
+  organization: entity({
+    relations: {
+      member: relation('user'),
+    },
+    permissions: {
+      view: permission('member'),
+    },
+  }),
+  document: entity({
+    relations: {
+      owner: relation('user'),
+      parent: relation('organization'),
+    },
+    permissions: {
+      view: permission('owner or parent.view'),
+      edit: permission('owner'),
+    },
+  }),
+});
+
+/**
+ * Schema-typed CheckPermission. Accepts 'document.view', 'view', etc. —
+ * anything outside the schema fails to compile.
+ */
+export const { CheckPermission } = createPermifyDecorators<typeof appSchema>();

--- a/simulator/backend/src/documents.controller.ts
+++ b/simulator/backend/src/documents.controller.ts
@@ -8,15 +8,22 @@ import {
 import type { Request } from 'express';
 import {
   PermifyGuard,
-  CheckPermission,
   PermifyResolvers,
+  PermissionResult,
+  type PermissionCheckResult,
 } from '@permify-toolkit/nestjs';
+import { CheckPermission } from './auth.js';
 
 @Controller('documents')
 export class DocumentsController {
   @UseGuards(PermifyGuard)
-  // checks if user has 'view' AND 'edit' permissions
-  @CheckPermission(['view', 'edit'])
+  /**
+   * CheckPermission here is the schema-typed variant from auth.ts —
+   * any name not defined in the schema is a compile error.
+   * OR mode: viewers get in, and the handler inspects the individual
+   * results to tell editors apart without a second Permify call.
+   */
+  @CheckPermission(['document.view', 'document.edit'], { mode: 'OR' })
   @PermifyResolvers({
     resource: (ctx: ExecutionContext) => {
       const req = ctx.switchToHttp().getRequest<Request>();
@@ -30,11 +37,22 @@ export class DocumentsController {
     },
   })
   @Get(':id')
-  view(@Param('id') id: string) {
+  view(
+    @Param('id') id: string,
+    @PermissionResult() results: PermissionCheckResult[],
+  ) {
+    /**
+     * The guard already checked both permissions; @PermissionResult()
+     * injects those outcomes so we can shape the response per ability.
+     * Result entries carry the bare action name ('edit'), the guard
+     * strips the 'document.' prefix before checking.
+     */
+    const canEdit = results.some((r) => r.permission === 'edit' && r.allowed);
     return {
       id,
       content: `Content of document ${id}`,
       access: 'granted',
+      canEdit,
     };
   }
 }


### PR DESCRIPTION
## Summary

Completes the permission typed decorator from roadmap. It gives users the ability to export a decorator from schema that will be used to caught compile time errors for the schema keywords used to check permission anywhere.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / chore

## Affected Package(s)

- [x] `@permify-toolkit/core`
- [x] `@permify-toolkit/nestjs`
- [ ] `@permify-toolkit/cli`
- [x] Simulator / docs

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the existing style (ran `pnpm lint` and `pnpm format:check`)
- [x] Tests are passing (`pnpm test`)
- [x] I have added/updated tests for new behavior
- [x] I have run `pnpm changeset` if this change affects a published package
- [x] Public API changes are reflected in `src/public-api.ts`

## Related Issues

none
