### PR TITLE
feat: implement optional permission name for @PermissionResult() to r…

### DIFF
--- a/.changeset/permission-result-lookup.md
+++ b/.changeset/permission-result-lookup.md
@@ -1,0 +1,5 @@
+---
+"@permify-toolkit/nestjs": minor
+---
+
+`@PermissionResult()` accepts an optional permission name and injects a boolean; qualified names (`document.edit`) are normalized to match guard results.

--- a/docs-site/docs/packages/nestjs.md
+++ b/docs-site/docs/packages/nestjs.md
@@ -280,7 +280,7 @@ import { CheckPermission } from "./auth";
 @CheckPermission("document.rename")             // ❌ compile error — not in the schema
 ```
 
-Both permissions and relations are accepted, in qualified (`"document.edit"`) and bare (`"edit"`) form the same set the guard resolves at runtime. Options like `{ mode: "OR" }` work identically to the untyped decorator.
+Both permissions and relations are accepted, in qualified (`"document.edit"`) and bare (`"edit"`) form the same set the guard resolves at runtime. Options like `{ mode: "OR" }` work identically to the untyped decorator. The factory also returns a typed `PermissionResult`, so `@PermissionResult("document.edit")` gets the same compile-time name checking.
 
 :::info
 Typed names require a DSL-defined schema. If you use `schemaFile()` with a `.perm` file, keep using the untyped `@CheckPermission` or mirror the schema in the DSL to get typing (see the [simulator](https://github.com/thisisnkc/permify-toolkit/blob/main/simulator/backend/src/auth.ts) for an example).
@@ -297,13 +297,14 @@ Typed names require a DSL-defined schema. If you use `schemaFile()` with a `.per
 
 When a route has multiple permissions checked with OR mode, you often need to know _which_ ones passed, to conditionally include data, set flags, or write audit logs. `@PermissionResult()` injects the guard's results directly into the handler, with no second round-trip to Permify.
 
+Pass a permission name to inject a single boolean — the common case:
+
 ```typescript
 import { Controller, Get, Param, UseGuards } from "@nestjs/common";
 import {
   CheckPermission,
   PermifyGuard,
-  PermissionResult,
-  type PermissionCheckResult
+  PermissionResult
 } from "@permify-toolkit/nestjs";
 
 @Controller("documents")
@@ -313,15 +314,27 @@ export class DocumentsController {
   @CheckPermission(["document.view", "document.edit"], { mode: "OR" })
   async getDocument(
     @Param("id") id: string,
-    @PermissionResult() permissions: PermissionCheckResult[]
+    @PermissionResult("document.edit") canEdit: boolean
   ) {
-    const canEdit = permissions.find((p) => p.permission === "edit")?.allowed;
-
     return {
       document: await this.documentService.findOne(id),
-      editable: canEdit ?? false // surface to frontend — no second gRPC call
+      editable: canEdit // surface to frontend — no second gRPC call
     };
   }
+}
+```
+
+Qualified (`"document.edit"`) and bare (`"edit"`) names both match the guard's results. A name that was never checked on the route injects `false` — unknown names fail closed.
+
+Without an argument, `@PermissionResult()` injects the full results array — useful for audit logging or when you need several flags at once:
+
+```typescript
+async getDocument(
+  @Param("id") id: string,
+  @PermissionResult() permissions: PermissionCheckResult[]
+) {
+  const canEdit = permissions.find((p) => p.permission === "edit")?.allowed;
+  // ...
 }
 ```
 
@@ -335,7 +348,7 @@ interface PermissionCheckResult {
 ```
 
 :::info
-`@PermissionResult()` requires `PermifyGuard` to have already run on the route. It returns `[]` on public routes where no guard ran.
+`@PermissionResult()` requires `PermifyGuard` to have already run on the route. On public routes where no guard ran, the array form returns `[]` and the boolean form returns `false`.
 :::
 
 **Common uses:**

--- a/docs-site/docs/roadmap.md
+++ b/docs-site/docs/roadmap.md
@@ -17,6 +17,7 @@ What we've shipped and what's next.
 
 - [x] Multi permission checks (AND + OR logic)
 - [x] `@PermissionResult()` decorator to access check results inside handlers without re-checking
+- [x] `@PermissionResult('document.edit')` boolean form to inject a single permission outcome by name
 - [ ] Permission caching via NestJS `CacheModule`
 - [ ] Audit logging interceptor for permission check decisions
 - [x] Typed entity and permission names from the schema DSL

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -84,22 +84,42 @@ export const CheckPermission = (
  * Parameter decorator that injects the permission check results computed by
  * {@link PermifyGuard} into the handler method.
  *
- * Requires the guard to have already run for this route. Returns an empty
- * array when no guard ran (public routes).
+ * Without an argument it injects the full results array. With a permission
+ * name it injects a single boolean — `true` only when that permission was
+ * checked and granted. Qualified names ("document.edit") match the bare
+ * form stored by the guard ("edit").
+ *
+ * Requires the guard to have already run for this route. When no guard ran
+ * (public routes), the array form returns `[]` and the boolean form
+ * returns `false`.
  *
  * @example
  * ```typescript
  * @UseGuards(PermifyGuard)
  * @CheckPermission(['document.view', 'document.edit'], { mode: 'OR' })
  * @Get(':id')
- * async get(@PermissionResult() results: PermissionCheckResult[]) {
- *   const canEdit = results.find(r => r.permission === 'edit')?.allowed;
- * }
+ * async get(
+ *   @PermissionResult() results: PermissionCheckResult[],
+ *   @PermissionResult('document.edit') canEdit: boolean
+ * ) { ... }
  * ```
  */
 export const PermissionResult = createParamDecorator(
-  (_data: unknown, ctx: ExecutionContext): PermissionCheckResult[] =>
-    (ctx.switchToHttp().getRequest<Record<string, unknown>>()[
-      PERMIFY_RESULT_KEY
-    ] as PermissionCheckResult[] | undefined) ?? []
+  (
+    data: string | undefined,
+    ctx: ExecutionContext
+  ): PermissionCheckResult[] | boolean => {
+    const results =
+      (ctx.switchToHttp().getRequest<Record<string, unknown>>()[
+        PERMIFY_RESULT_KEY
+      ] as PermissionCheckResult[] | undefined) ?? [];
+
+    if (data === undefined) {
+      return results;
+    }
+
+    const parts = data.split(".");
+    const bare = parts.length > 1 ? parts[1] : data;
+    return results.some((r) => r.permission === bare && r.allowed);
+  }
 );

--- a/packages/nestjs/src/typed-decorators.ts
+++ b/packages/nestjs/src/typed-decorators.ts
@@ -1,14 +1,18 @@
 import type { SchemaHandle, PermissionName } from "@permify-toolkit/core";
 
-import { CheckPermission, type CheckPermissionOptions } from "./decorators.js";
+import {
+  CheckPermission,
+  PermissionResult,
+  type CheckPermissionOptions
+} from "./decorators.js";
 
 /**
  * Creates decorators typed against a specific schema.
  *
- * The returned `CheckPermission` behaves identically to the base decorator but
- * only accepts identifiers that exist in the given schema — both qualified
- * (`"document.view"`) and bare (`"view"`) forms. Invalid names are a compile
- * error, and editors autocomplete the valid ones.
+ * The returned `CheckPermission` and `PermissionResult` behave identically
+ * to the base decorators but only accept identifiers that exist in the given
+ * schema — both qualified (`"document.view"`) and bare (`"view"`) forms.
+ * Invalid names are a compile error, and editors autocomplete the valid ones.
  *
  * Bind it once to your schema and re-export it from your auth module.
  *
@@ -18,7 +22,7 @@ import { CheckPermission, type CheckPermissionOptions } from "./decorators.js";
  * import { createPermifyDecorators } from '@permify-toolkit/nestjs';
  * import { appSchema } from './permify.config';
  *
- * export const { CheckPermission } =
+ * export const { CheckPermission, PermissionResult } =
  *   createPermifyDecorators<typeof appSchema>();
  *
  * // controller.ts
@@ -33,6 +37,7 @@ export function createPermifyDecorators<H extends SchemaHandle>() {
     CheckPermission: (
       permissions: Name | Name[],
       options?: CheckPermissionOptions
-    ) => CheckPermission(permissions, options)
+    ) => CheckPermission(permissions, options),
+    PermissionResult: (permission?: Name) => PermissionResult(permission)
   };
 }

--- a/packages/nestjs/tests/decorators.spec.ts
+++ b/packages/nestjs/tests/decorators.spec.ts
@@ -122,4 +122,68 @@ test.group("PermissionResult decorator", () => {
     const result = factory(undefined, ctx) as PermissionCheckResult[];
     assert.deepEqual(result, []);
   });
+
+  function getFactory(assert: any) {
+    class C {
+      handler(@PermissionResult() _allowed: boolean) {}
+    }
+    const argsMetadata =
+      (Reflect.getMetadata("__routeArguments__", C, "handler") as Record<
+        string,
+        any
+      >) ?? {};
+    const factory = Object.values(argsMetadata)[0]?.factory;
+    assert.isFunction(
+      factory,
+      "Expected NestJS to register param decorator factory"
+    );
+    return factory;
+  }
+
+  test("returns true for a granted permission name", ({ assert }) => {
+    const stored: PermissionCheckResult[] = [
+      { permission: "edit", allowed: true }
+    ];
+    const ctx = makeCtx({ [PERMIFY_RESULT_KEY]: stored });
+    const factory = getFactory(assert);
+
+    assert.isTrue(factory("edit", ctx));
+  });
+
+  test("matches qualified name against bare stored result", ({ assert }) => {
+    const stored: PermissionCheckResult[] = [
+      { permission: "edit", allowed: true }
+    ];
+    const ctx = makeCtx({ [PERMIFY_RESULT_KEY]: stored });
+    const factory = getFactory(assert);
+
+    assert.isTrue(factory("document.edit", ctx));
+  });
+
+  test("returns false for a denied permission name", ({ assert }) => {
+    const stored: PermissionCheckResult[] = [
+      { permission: "edit", allowed: false }
+    ];
+    const ctx = makeCtx({ [PERMIFY_RESULT_KEY]: stored });
+    const factory = getFactory(assert);
+
+    assert.isFalse(factory("edit", ctx));
+  });
+
+  test("returns false for a name never checked on the route", ({ assert }) => {
+    const stored: PermissionCheckResult[] = [
+      { permission: "view", allowed: true }
+    ];
+    const ctx = makeCtx({ [PERMIFY_RESULT_KEY]: stored });
+    const factory = getFactory(assert);
+
+    assert.isFalse(factory("edit", ctx));
+  });
+
+  test("returns false with a name when no guard ran", ({ assert }) => {
+    const ctx = makeCtx({});
+    const factory = getFactory(assert);
+
+    assert.isFalse(factory("edit", ctx));
+  });
 });

--- a/packages/nestjs/tests/typed-decorators.spec.ts
+++ b/packages/nestjs/tests/typed-decorators.spec.ts
@@ -14,7 +14,8 @@ const _appSchema = schema({
   })
 });
 
-const { CheckPermission } = createPermifyDecorators<typeof _appSchema>();
+const { CheckPermission, PermissionResult } =
+  createPermifyDecorators<typeof _appSchema>();
 
 const getMetadata = (target: object) =>
   Reflect.getMetadata(PERMIFY_PERMISSION_KEY, target);
@@ -52,6 +53,24 @@ test.group("createPermifyDecorators", () => {
     assert.deepEqual(metadata.permissions, ["view", "owner"]);
   });
 
+  test("typed PermissionResult delegates to base decorator", ({ assert }) => {
+    class TestClass {
+      handler(@PermissionResult("document.edit") _allowed: boolean) {}
+    }
+
+    const argsMetadata =
+      (Reflect.getMetadata(
+        "__routeArguments__",
+        TestClass,
+        "handler"
+      ) as Record<string, any>) ?? {};
+    const factory = Object.values(argsMetadata)[0]?.factory;
+    assert.isFunction(
+      factory,
+      "Expected NestJS to register param decorator factory"
+    );
+  });
+
   /**
    * Compile-time guarantees. These assertions are enforced by `tsc`
    * (`pnpm typecheck`), not at runtime, so the test body is trivial.
@@ -69,6 +88,9 @@ test.group("createPermifyDecorators", () => {
       // @ts-expect-error "delete" is not a name in the schema
       @CheckPermission(["view", "delete"])
       c() {}
+
+      // @ts-expect-error "document.xyz" is not a valid permission
+      d(@PermissionResult("document.xyz") _allowed: boolean) {}
     }
 
     assert.isFunction(TestClass.prototype.a);

--- a/simulator/backend/src/auth.ts
+++ b/simulator/backend/src/auth.ts
@@ -29,7 +29,8 @@ export const appSchema = schema({
 });
 
 /**
- * Schema-typed CheckPermission. Accepts 'document.view', 'view', etc. —
- * anything outside the schema fails to compile.
+ * Schema-typed CheckPermission and PermissionResult. Accept 'document.view',
+ * 'view', etc. — anything outside the schema fails to compile.
  */
-export const { CheckPermission } = createPermifyDecorators<typeof appSchema>();
+export const { CheckPermission, PermissionResult } =
+  createPermifyDecorators<typeof appSchema>();

--- a/simulator/backend/src/documents.controller.ts
+++ b/simulator/backend/src/documents.controller.ts
@@ -6,22 +6,17 @@ import {
   type ExecutionContext,
 } from '@nestjs/common';
 import type { Request } from 'express';
-import {
-  PermifyGuard,
-  PermifyResolvers,
-  PermissionResult,
-  type PermissionCheckResult,
-} from '@permify-toolkit/nestjs';
-import { CheckPermission } from './auth.js';
+import { PermifyGuard, PermifyResolvers } from '@permify-toolkit/nestjs';
+import { CheckPermission, PermissionResult } from './auth.js';
 
 @Controller('documents')
 export class DocumentsController {
   @UseGuards(PermifyGuard)
   /**
-   * CheckPermission here is the schema-typed variant from auth.ts —
-   * any name not defined in the schema is a compile error.
-   * OR mode: viewers get in, and the handler inspects the individual
-   * results to tell editors apart without a second Permify call.
+   * CheckPermission and PermissionResult here are the schema-typed
+   * variants from auth.ts — any name not defined in the schema is a
+   * compile error. OR mode: viewers get in, and editors are told apart
+   * without a second Permify call.
    */
   @CheckPermission(['document.view', 'document.edit'], { mode: 'OR' })
   @PermifyResolvers({
@@ -39,15 +34,12 @@ export class DocumentsController {
   @Get(':id')
   view(
     @Param('id') id: string,
-    @PermissionResult() results: PermissionCheckResult[],
+    @PermissionResult('document.edit') canEdit: boolean,
   ) {
     /**
-     * The guard already checked both permissions; @PermissionResult()
-     * injects those outcomes so we can shape the response per ability.
-     * Result entries carry the bare action name ('edit'), the guard
-     * strips the 'document.' prefix before checking.
+     * The guard checked both permissions; the decorator injects the
+     * edit outcome as a boolean.
      */
-    const canEdit = results.some((r) => r.permission === 'edit' && r.allowed);
     return {
       id,
       content: `Content of document ${id}`,


### PR DESCRIPTION
## Summary

Permission result improvements, now no need to loop through every permission to get what is allowed, use simple can<Permission>.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## Affected Package(s)

- [ ] `@permify-toolkit/core`
- [X] `@permify-toolkit/nestjs`
- [ ] `@permify-toolkit/cli`
- [ ] Simulator / docs